### PR TITLE
support diagrams and rename playbooks to guides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 VENV_PATH ?= ./.venv
-VENV_REQ ?= requirements.txt
+VENV_REQ ?= docs/requirements.txt
 
 .PHONY: venv
 venv:
@@ -10,6 +10,15 @@ venv:
 requirements: venv
 	$(VENV_PATH)/bin/pip3 install --upgrade pip
 	$(VENV_PATH)/bin/pip3 install -r $(VENV_REQ)
+
+# Vercel
+.PHONY: ci-dependencies
+ci-dependencies:
+	cat /etc/os-release
+	yum install -y python3-pip graphviz
+
+.PHONY: ci-install
+ci-install: ci-dependencies requirements
 
 mkdocs-serve:
 	$(VENV_PATH)/bin/mkdocs serve

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+images/
+diagrams/images/

--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -1,5 +1,5 @@
-# Runbooks | Home
+# Guides | Home
 
-This is a set of procedures to achieve specific goal, in ITSM it's called runbooks or playbooks, or sometimes How-Tos. =)
+This is a set of guides randomly organized. =)
 
-Those procedures are not linked with any product or company, and does not provide any warranty. **You should run it for your responsability**.
+Those procedures are not linked with any product or company, and does not provide any warranty. **You should run it for your own responsability and risks**.

--- a/docs/playbooks/openshift/hypershift-install-sts.md
+++ b/docs/playbooks/openshift/hypershift-install-sts.md
@@ -1,4 +1,4 @@
-# Installing Hypershift on AWS with STS (unfinished/unsupported)
+# Installing Hypershift on AWS with STS (unfinished/wip)
 
 Steps to create a cluster with authentication mode with STS in AWS, then install Hypershift using STS (unfinished/unsupported).
 

--- a/docs/playbooks/openshift/ocp-aws-cco-sts-install-quickly.md
+++ b/docs/playbooks/openshift/ocp-aws-cco-sts-install-quickly.md
@@ -1,4 +1,4 @@
-# OCP on AWS - Install cluster with STS with a single command
+# OCP on AWS - Installing a cluster with STS quickly on AWS
 
 Install the OCP cluster on AWS with manual Authentication with STS with a single command.
 
@@ -176,7 +176,7 @@ CLUSTER_VERSION="4.11.10" &&\
 - Create the cluster patching the Cloud Credential secrets to add the regional endpoint option:
 
 ```bash
-  PATCH_SECRETS_REGIONAL=true &&\
+PATCH_SECRETS_REGIONAL=true &&\
   CLUSTER_VERSION="4.12.0-ec.4" &&\
   CLUSTER_NAME="labsts4120ec4t1" &&\
   CLUSTER_BASE_DOMAIN="devcluster.openshift.com" &&\

--- a/docs/playbooks/openshift/ocp-aws-create-compute.md
+++ b/docs/playbooks/openshift/ocp-aws-create-compute.md
@@ -1,10 +1,16 @@
 # OpenShift | AWS | Steps to Create a node manually
 
-Steps:
+Steps to crate an EC2 manually based on existing Machine Set.
+
+Reasons to follow that guide:
+
+- Testing parameters not allowed by Machine Set provider spec.
+
+## Steps
 
 - Create the subnet
 
-```
+```bash
 CLUSTER_ID=mrb-ffj2l
 VPC_NAME=${CLUSTER_ID}-vpc
 VPC_ID=$(aws ec2 describe-vpcs --filters Name=tag:Name,Values=${VPC_NAME} |jq -r .Vpcs[0].VpcId)
@@ -38,12 +44,13 @@ aws ec2 create-subnet --cli-input-json "$(cat subnet-new.json)"
 
 - Check instance availability
 
-```
+```bash
 $ aws ec2 describe-instance-type-offerings --location-type availability-zone --filters Name=location,Values=${AZ_NAME} --region ${REGION}
 ```
 
 - Create the instance
-```
+
+```bash
 # CHANGE_ME:
 REGION="us-east-1"
 # Subnet in us-east-1-bos-1a
@@ -79,5 +86,6 @@ aws ec2 run-instances                     \
     --block-device-mappings "VirtualName=/dev/nvme0n1,DeviceName=/dev/xvda,Ebs={VolumeSize=${DISK_SIZE}}" \
     --user-data "file://${USERDATA}" \
     --iam-instance-profile Name=${PROFILE_NAME}
-
 ```
+
+- Approve the certificate

--- a/docs/playbooks/openshift/ocp-aws-vpc-shared.md
+++ b/docs/playbooks/openshift/ocp-aws-vpc-shared.md
@@ -1,4 +1,4 @@
-# Lab - OCP VPC-Shared Installation Steps
+# Lab - OCP VPC-Shared Installation Steps (WIP)
 
 > Note: incomplete due to limitations.
 
@@ -87,3 +87,6 @@ AWS_ACCESS_KEY_ID=${ACCOUNT_A_AKID} \
 ### Create resources on Shared-VPC
 
 - Return to `Account B` and run instances in the shared VPC
+
+
+(...)

--- a/docs/playbooks/openshift/ocp-cco-review-sts-secrets.md
+++ b/docs/playbooks/openshift/ocp-cco-review-sts-secrets.md
@@ -1,5 +1,11 @@
 # OCP on AWS - Review CredentialsRequests provided by CCO
 
+Steps to review the existing CredentialsRequests provided by CCO from a given OpenShift release version.
+
+It will extract the CredentialsRequests from a release (required) versus the running on the cluster (secrets).
+
+Steps:
+
 - Get the credentials expected to the release
 
 ```bash

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,13 @@
+mkdocs>=1.3,<1.5
+mkdocs-material
+pymdown-extensions
+
+mkdocs-material
+mkdocs-mermaid2-plugin
+
+# Diagram as a code with mingrammer https://diagrams.mingrammer.com/
+## Require graphviz
+mkdocs-diagrams
+
+# Image resizing
+Pillow>=9.4,<9.5

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -3,13 +3,13 @@
 - your IPv4
 
 ``` shell
-curl https://mtulio.eng.br/api/ip
+curl https://mtulio.net/api/ip
 ```
 
 - your IPv4 (json output)
 
 ``` shell
-curl -s https://mtulio.eng.br/api/ip?json |jq .
+curl -s https://mtulio.net/api/ip/ip?json |jq .
 ```
 
 ``` json
@@ -23,7 +23,7 @@ curl -s https://mtulio.eng.br/api/ip?json |jq .
 - http echo
 
 ``` shell
-curl -s https://mtulio.eng.br/api/echo
+curl -s https://mtulio.net/api/echo
 ```
 - http echo (request headers)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,12 +4,9 @@ site_author: 'Marco Braga'
 site_description: >-
   Marco Braga | Playground
 repo_url: https://github.com/mtulio/mtulio.labs
-
+edit_uri: edit/main/docs/
 docs_dir: docs
-
-# theme:
-#   name: cerulean
-#   nav_style: dark
+dev_addr: 127.0.0.1:8080
 
 theme:
   # https://github.com/squidfunk/mkdocs-material/blob/master/mkdocs.yml
@@ -30,12 +27,12 @@ theme:
         icon: material/lightbulb
         name: Switch to dark mode
 
-
   features:
     - navigation.tabs
     - navigation.tabs.sticky
     #- navigation.sections
     - navigation.top
+    #- navigation.indexes
 
     # integrate menus
     #- toc.integrate
@@ -47,10 +44,26 @@ theme:
   font:
     text: Roboto
     code: Roboto Mono
-  
 
-# plugins:
-#   - social
+plugins:
+  - diagrams:
+      file_extension: ".diagram.py"
+      max_workers: 5
+
+markdown_extensions:
+  # - toc:
+  #     permalink: true
+  - admonition
+  - pymdownx.superfences
+  - pymdownx.details
+  - pymdownx.tabbed:
+      alternate_style: true
+  # enable mermaid
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
 
 extra:
   analytics:
@@ -73,38 +86,44 @@ extra:
     - icon: fontawesome/brands/linkedin
       link: https://linkedin.com/in/mtuliorbraga/
 
-markdown_extensions:
-  # - toc:
-  #     permalink: true
-  - admonition
-  - pymdownx.superfences
-  - pymdownx.details
-  - pymdownx.tabbed:
-      alternate_style: true
-  
-
 nav:
   - Home:
     - index.md
-    - about.md
-    - tools.md
-  - Runbooks:
+    # - about.md
+    # - tools.md
+  - Guides:
       - Home: playbooks/README.md
-      - OpenShift:
+      - OpenShift API:
+        - Replace Kube-API AWS NLB target type: playbooks/openshift/replace-nlb-tg-k8sapi.md
+
+      - OpenShift Node/Machine operations:
         - Machine resize: playbooks/openshift/resize-machines.md
         - Machine resize plugin: playbooks/openshift/resize-machines-plugin.md
-        - Replace Kube-API AWS NLB target type: playbooks/openshift/replace-nlb-tg-k8sapi.md
-        - Hacking CCO STS manual mode: playbooks/openshift/ocp-aws-cco-run-instance.md
-        - Quickly install an OCP cluster in AWS with STS: playbooks/openshift/ocp-aws-cco-sts-install-quickly.md
-        - AWS STS - Simulate CredentialsRequests permissions: playbooks/openshift/ocp-aws-cco-simulate-policy.md
-        - AWS STS - Troubleshooting RunInstance Error: playbooks/openshift/ocp-aws-cco-sts-runinstance-error-kcs.md
-        - Installing Hypershift on AWS with STS: playbooks/openshift/hypershift-install-sts.md
         - Using Instance Disks for containers' ephemeral storage: playbooks/openshift/ocp-aws-disk-ephemeral.md
+        - AWS - Create EC2 manually: playbooks/openshift/ocp-aws-create-compute.md
+
+      - OpenShift Installing:
+        - Installing OpenShift with STS quickly on AWS: playbooks/openshift/ocp-aws-cco-sts-install-quickly.md
+        - Installing OpenShift on Alibaba Cloud in existing VPC: playbooks/openshift/ocp-installing-alibabacloud.md
+        - Installing OpenShift on Alibaba Cloud in restricted environment [draft]: playbooks/openshift/ocp-installing-alibabacloud.md
+        - Installing Hypershift on AWS with STS (draft/unfinished): playbooks/openshift/hypershift-install-sts.md
+        - Installing single node (SNO) on AWS [draft]: playbooks/openshift/ocp-aws-sno-install.md
+
+      - OpenShift on AWS with STS:
+        - Articles: playbooks/openshift/ocp-aws-cco-oidc.md
+        - Hacking CCO manual mode: playbooks/openshift/ocp-aws-cco-run-instance.md
+        - Simulate CredentialsRequests permissions: playbooks/openshift/ocp-aws-cco-simulate-policy.md
+        - Troubleshooting RunInstance Error: playbooks/openshift/ocp-aws-cco-sts-runinstance-error-kcs.md
+        - Troubleshooting InvalidIdentityToken: playbooks/openshift/ocp-installing-aws-sts-oidc-private-bucket.md
+        - Review CredentialsRequests provided by CCO: playbooks/openshift/ocp-cco-review-sts-secrets.md
+
       - OpenShift Dev:
         - Build components: playbooks/openshift/dev-build-components.md
         - Create custom release: playbooks/openshift/dev-custom-release.md
         - Get Credentials with CI Registry: playbooks/openshift/install-credentials-with-ci.md
         - Extract openshift-tests utility: playbooks/openshift/dev-extract-openshift-tests.md
+
+      #- OpenShift in AWS:
 
   - Notes:
     - Home: notes/README.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-mkdocs
-#mkdocs-bootswatch
-mkdocs-material
-pymdown-extensions

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "installCommand": "make ci-install",
+  "buildCommand": "make mkdocs-build",
+  "outputDirectory": "site"
+}


### PR DESCRIPTION
- Support Diagrams as a code with migrammer and graphviz
- review mkdocs index: rename "Playbooks" to "Guides"
- Review main guides to improve the visibility of the current state