### PR TITLE
Blog Series for AWS Local Zones: 4.13+

### DIFF
--- a/docs/blogs/ocp-aws-local-zones/ocp-aws-local-zones-413-script.md
+++ b/docs/blogs/ocp-aws-local-zones/ocp-aws-local-zones-413-script.md
@@ -1,0 +1,280 @@
+# Script for blog: Extending Red Hat OpenShift Container Platform to AWS Local Zones
+
+## Prerequisites
+
+- AWS CLI
+- Templates
+
+~~~bash
+oc adm release extract --tools quay.io/openshift-release-dev/ocp-release:4.13.1-x86_64 -a ~/.openshift/pull-secret-latest.json
+tar xfz openshift-install-linux-4.13.1.tar.gz
+~~~
+
+## Steps
+
+- Install a cluster
+
+~~~bash
+export CLUSTER_NAME=demo-lz
+export CLUSTER_BASEDOMAIN="devcluster.openshift.com"
+export PULL_SECRET_PATH="$HOME/.openshift/pull-secret-latest.json"
+export SSH_KEYS="$(cat ~/.ssh/id_rsa.pub)"
+export AWS_REGION=us-east-1
+
+# VPC
+export STACK_VPC=${CLUSTER_NAME}-vpc
+aws cloudformation create-stack --stack-name ${STACK_VPC} \
+     --template-body file://template-vpc.yaml \
+     --parameters \
+        ParameterKey=ClusterName,ParameterValue=${CLUSTER_NAME} \
+        ParameterKey=VpcCidr,ParameterValue="10.0.0.0/16" \
+        ParameterKey=AvailabilityZoneCount,ParameterValue=3 \
+        ParameterKey=SubnetBits,ParameterValue=12
+
+aws cloudformation wait stack-create-complete --stack-name ${STACK_VPC}
+aws cloudformation describe-stacks --stack-name ${STACK_VPC}
+
+# Local Zone subnet
+export STACK_LZ=${CLUSTER_NAME}-lz-nyc-1a
+export ZONE_GROUP_NAME=${AWS_REGION}-nyc-1
+
+export VPC_ID=$(aws cloudformation describe-stacks \
+  --stack-name ${STACK_VPC} \
+  | jq -r '.Stacks[0].Outputs[] | select(.OutputKey=="VpcId").OutputValue' )
+
+export VPC_RTB_PUB=$(aws cloudformation describe-stacks \
+  --stack-name ${STACK_VPC} \
+  | jq -r '.Stacks[0].Outputs[] | select(.OutputKey=="PublicRouteTableId").OutputValue' )
+
+aws ec2 modify-availability-zone-group \
+    --group-name "${ZONE_GROUP_NAME}" \
+    --opt-in-status opted-in
+
+aws cloudformation create-stack --stack-name ${STACK_LZ} \
+     --template-body file://template-lz.yaml \
+     --parameters \
+        ParameterKey=ClusterName,ParameterValue="${CLUSTER_NAME}" \
+        ParameterKey=VpcId,ParameterValue="${VPC_ID}" \
+        ParameterKey=PublicRouteTableId,ParameterValue="${VPC_RTB_PUB}" \
+        ParameterKey=LocalZoneName,ParameterValue="${ZONE_GROUP_NAME}a" \
+        ParameterKey=LocalZoneNameShort,ParameterValue="nyc-1a" \
+        ParameterKey=PublicSubnetCidr,ParameterValue="10.0.128.0/20"
+
+aws cloudformation wait stack-create-complete --stack-name ${STACK_LZ} 
+
+aws cloudformation describe-stacks --stack-name ${STACK_LZ}
+
+
+mapfile -t SUBNETS < <(aws cloudformation describe-stacks \
+  --stack-name "${STACK_VPC}" \
+  | jq -r '.Stacks[0].Outputs[0].OutputValue' | tr ',' '\n')
+
+mapfile -t -O "${#SUBNETS[@]}" SUBNETS < <(aws cloudformation describe-stacks \
+  --stack-name "${STACK_VPC}" \
+  | jq -r '.Stacks[0].Outputs[1].OutputValue' | tr ',' '\n')
+
+# Set the SUBNET_ID to be used later
+export SUBNET_ID=$(aws cloudformation describe-stacks --stack-name "${STACK_LZ}" \
+  | jq -r .Stacks[0].Outputs[0].OutputValue)
+
+# Append the Local Zone subnet to the subnet ID list
+SUBNETS+=(${SUBNET_ID})
+
+cat <<EOF > ${PWD}/install-config.yaml
+apiVersion: v1
+publish: External
+baseDomain: "${CLUSTER_BASEDOMAIN}"
+metadata:
+  name: "${CLUSTER_NAME}"
+platform:
+  aws:
+    region: ${AWS_REGION}
+    subnets:
+$(for SB in ${SUBNETS[*]}; do echo "    - $SB"; done)
+pullSecret: '$(cat ${PULL_SECRET_PATH} | awk -v ORS= -v OFS= '{$1=$1}1')'
+sshKey: |
+  ${SSH_KEYS}
+EOF
+
+grep -A 7 subnets ${PWD}/install-config.yaml
+
+cp ${PWD}/install-config.yaml ${PWD}/install-config.yaml-bkp
+
+./openshift-install create manifests
+
+ls manifests/cluster-network-*
+ls openshift/99_openshift-cluster-api_worker-machineset-*
+
+./openshift-install create cluster
+
+
+# Wait for the cluster creation
+
+export KUBECONFIG=$PWD/auth/kubeconfig
+oc get nodes -l node-role.kubernetes.io/edge
+
+oc get machineset -n openshift-machine-api
+oc get machine -n openshift-machine-api
+~~~
+
+## Create new node in Day 2
+
+- create zone in bue
+
+~~~bash
+# Local Zone subnet
+export STACK_LZ=${CLUSTER_NAME}-lz-bue-1a
+export ZONE_GROUP_NAME=${AWS_REGION}-bue-1
+export CIDR_BLOCK=10.0.144.0/20
+
+export VPC_ID=$(aws cloudformation describe-stacks \
+  --stack-name ${STACK_VPC} \
+  | jq -r '.Stacks[0].Outputs[] | select(.OutputKey=="VpcId").OutputValue' )
+
+export VPC_RTB_PUB=$(aws cloudformation describe-stacks \
+  --stack-name ${STACK_VPC} \
+  | jq -r '.Stacks[0].Outputs[] | select(.OutputKey=="PublicRouteTableId").OutputValue' )
+
+aws ec2 modify-availability-zone-group \
+    --group-name "${ZONE_GROUP_NAME}" \
+    --opt-in-status opted-in
+
+aws cloudformation create-stack --stack-name ${STACK_LZ} \
+     --template-body file://template-lz.yaml \
+     --parameters \
+        ParameterKey=ClusterName,ParameterValue="${CLUSTER_NAME}" \
+        ParameterKey=VpcId,ParameterValue="${VPC_ID}" \
+        ParameterKey=PublicRouteTableId,ParameterValue="${VPC_RTB_PUB}" \
+        ParameterKey=LocalZoneName,ParameterValue="${ZONE_GROUP_NAME}a" \
+        ParameterKey=LocalZoneNameShort,ParameterValue="bue-1a" \
+        ParameterKey=PublicSubnetCidr,ParameterValue="${CIDR_BLOCK}"
+
+aws cloudformation wait stack-create-complete --stack-name ${STACK_LZ} 
+
+aws cloudformation describe-stacks --stack-name ${STACK_LZ}
+
+export SUBNET_ID_BUE=$(aws cloudformation describe-stacks --stack-name "${STACK_LZ}" \
+  | jq -r .Stacks[0].Outputs[0].OutputValue)
+~~~
+
+- Create machineset
+~~~bash
+aws ec2 describe-instance-type-offerings \
+    --location-type availability-zone \
+    --filters Name=location,Values=${AWS_REGION}-bue-1a \
+    --region ${AWS_REGION}
+
+export INSTANCE_BUE=m5.2xlarge
+
+BASE_MANIFEST=$(oc get machineset -n openshift-machine-api -o jsonpath='{range .items[*].metadata}{.name}{"\n"}{end}' | grep nyc-1)
+oc get machineset -n openshift-machine-api $BASE_MANIFEST -o yaml > machineset-lz-bue-1a.yaml
+
+# replace the subnet ID from NYC to BUE
+sed -si "s/${SUBNET_ID}/${SUBNET_ID_BUE}/g" machineset-lz-bue-1a.yaml
+
+# replace the zone reference from NYC to BUE
+sed -si "s/nyc-1/bue-1/g" machineset-lz-bue-1a.yaml
+
+# replace the instance type to a new one
+current_instance=$(oc get machineset -n openshift-machine-api $BASE_MANIFEST -o jsonpath='{.spec.template.spec.providerSpec.value.instanceType}')
+sed -si "s/${current_instance}/${INSTANCE_BUE}/g" machineset-lz-bue-1a.yaml
+
+oc create -f machineset-lz-bue-1a.yaml
+
+oc get machines -w -n openshift-machine-api -l machine.openshift.io/cluster-api-machine-role=edge
+~~~
+
+## Installing ALB Operator (not covered by the blog / out of scope)
+
+~~~bash
+# Tag the VPC (PATCH)
+## https://docs.aws.amazon.com/cli/latest/reference/ec2/create-tags.html
+VPC_ID=$(aws ec2 describe-subnets --subnet-ids ${SUBNETS[0]} --query 'Subnets[0].VpcId' --output text)
+INFRA_ID="$(oc get infrastructure cluster -o jsonpath='{.status.infrastructureName}')"
+TAG_KEY="kubernetes.io/cluster/${INFRA_ID}"
+
+# Check and tag VPC when not exists
+aws ec2 describe-vpcs --vpc-ids $VPC_ID --query 'Vpcs[0].Tags[].Key' --output text | grep $TAG_KEY || aws ec2 create-tags --resources $VPC_ID --tags Key=$TAG_KEY,Value=shared
+
+
+# Install using OLM
+oc create namespace aws-load-balancer-operator
+cat << EOF| oc create -f -
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: aws-load-balancer-operator
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries:
+      - action:
+          - ec2:DescribeSubnets
+        effect: Allow
+        resource: "*"
+      - action:
+          - ec2:CreateTags
+          - ec2:DeleteTags
+        effect: Allow
+        resource: arn:aws:ec2:*:*:subnet/*
+      - action:
+          - ec2:DescribeVpcs
+        effect: Allow
+        resource: "*"
+  secretRef:
+    name: aws-load-balancer-operator
+    namespace: aws-load-balancer-operator
+  serviceAccountNames:
+    - aws-load-balancer-operator-controller-manager
+EOF
+
+
+cat <<EOF | oc create -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: aws-load-balancer-operator
+  namespace: aws-load-balancer-operator
+spec:
+  targetNamespaces:
+  - aws-load-balancer-operator
+EOF
+
+cat <<EOF | oc create -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: aws-load-balancer-operator
+  namespace: aws-load-balancer-operator
+spec:
+  channel: stable-v0
+  installPlanApproval: Automatic 
+  name: aws-load-balancer-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+oc get installplan -n aws-load-balancer-operator
+
+sleep 60
+
+oc get all -n aws-load-balancer-operator
+
+cat <<EOF | oc create -f -
+apiVersion: networking.olm.openshift.io/v1alpha1
+kind: AWSLoadBalancerController 
+metadata:
+  name: cluster 
+spec:
+  subnetTagging: Auto 
+  ingressClass: cloud 
+  config:
+    replicas: 2
+  enabledAddons: 
+    - AWSWAFv2
+EOF
+
+oc get all -n aws-load-balancer-operator
+~~~

--- a/docs/blogs/ocp-aws-local-zones/ocp-aws-local-zones-413.md
+++ b/docs/blogs/ocp-aws-local-zones/ocp-aws-local-zones-413.md
@@ -1,6 +1,6 @@
 # Extending Red Hat OpenShift Container Platform to AWS Local Zones
 
-> Authors: Marcos Entenza Garcia Marco Braga Fatih Nar
+> Authors: Marcos Entenza Garcia, Marco Braga, Fatih Nar
 
 ## Overview
 
@@ -21,7 +21,7 @@ Using OpenShift with Local Zones, application developers and service consumers w
 - Hosting resources in specific geographic locations leads to cost savings, whereby customers avoid high costs associated with data transfer charges, such as cloud egress charges, which is a significant business expense, when large volumes of data is moved between regions in the case of image, graphics, and video related applications). 
 - Provide healthcare, government agencies, financial institutions, and other regulated industries a way to meet data residency requirements by hosting data and applications in specific locations to comply with regulatory laws and mandates.
 
-Let's walk through the steps to install an OpenShift cluster in an existing virtual private cloud (VPC) in the US Virginia (us-east-1) region by creating a Local Zone subnet, OpenShift Machine Set manifests, and automatically launch worker nodes during the installation. This diagram below shows what gets created:
+Let's walk through the steps to install an OpenShift cluster in an existing virtual private cloud (VPC) in the US Virginia (us-east-1) region by creating a Local Zone subnet, OpenShift Machine Set manifests, and automatically launching worker nodes during the installation. The diagram below shows what gets created:
 
 - An standard OpenShift Cluster is installed in us-east-1 with three Control Plane nodes and three Compute nodes
 - One "edge" Compute node runs in the Local Zone subnet in the New York metropolitan region
@@ -30,6 +30,12 @@ Let's walk through the steps to install an OpenShift cluster in an existing virt
 ![aws-local-zones-diagram-blog-hc drawio](https://github.com/mtulio/mtulio.labs/assets/3216894/06d75201-82dd-4c13-963f-9850e8fc7d34)
 
 <p><center>Figure-2 OpenShift Cluster installed in us-east-1 extending nodes to Local Zone in New York</center></p>
+
+After the cluster is installed, we'll share how to add new Local Zones in Day 2 operations, deploy and expose workloads in Local Zones, evaluating the network connection time from different locations.
+
+![aws-local-zones-diagram-ocp-lz-413-map drawio](https://github.com/mtulio/mtulio.labs/assets/3216894/2fe7ae42-5b1a-4f7c-9e95-f063489eadc6)
+
+<p><center>Figure-3 User Workloads in Local Zones</center></p>
 
 
 ## Installing an OpenShift cluster with AWS Local Zones
@@ -44,12 +50,12 @@ Note the following considerations when deploying a cluster in AWS Local Zones:
 
 - The Maximum Transmission Unit (MTU) between an Amazon EC2 instance in a Local Zone and an Amazon EC2 instance in the Region is 1300. This causes the cluster-wide network MTU to change according to the network plugin that is used on the deployment.
 - Network resources such as Network Load Balancer (NLB), Classic Load Balancer, and Nat Gateways are not supported in AWS Local Zones.
-- The AWS Elastic Block Storage (EBS) gp3 type volume is the default for node volumes and the default for the storage class set on AWS OpenShift clusters. This volume type is not globally available in Local Zone locations. By default, the nodes running in Local Zones are deployed with the gp2 EBS volume. The gp2-csi StorageClass must be set when creating workloads on Local Zone nodes.
+- The AWS Elastic Block Storage (EBS) `gp3` type volume is the default for node volumes and the default for the storage class set on AWS OpenShift clusters. This volume type is not globally available in Local Zone locations. By default, the nodes running in Local Zones are deployed with the gp2 EBS volume. The `gp2-csi` StorageClass must be set when creating workloads on Local Zone nodes.
 
 Install the following prerequisites before you proceed to the next step:
 
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
-- [OpenShift Installer 4.12+](https://console.redhat.com/openshift/downloads)
+- [OpenShift Installer 4.13+](https://console.redhat.com/openshift/downloads)
 - [OpenShift CLI](https://console.redhat.com/openshift/downloads)
 
 ### Step 1.  Create the VPC
@@ -58,13 +64,16 @@ This section is optional. Create a VPC with your preferred customizations, as re
 Define the environment variables:
 
 ~~~bash
-$ export CLUSTER_REGION=us-east-1
-$ export CLUSTER_NAME=ocp-lz
+$ export CLUSTER_NAME=demo-lz
+$ export CLUSTER_BASEDOMAIN="example.com"
+$ export PULL_SECRET_PATH="$HOME/.openshift/pull-secret-latest.json"
+$ export SSH_KEYS="$(cat ~/.ssh/id_rsa.pub)"
+$ export AWS_REGION=us-east-1
 ~~~
 
 Download the following CloudFormation Templates with the following names:
 
-- template-vpc.yam : [CloudFormation template for the VPC that uses AWS Local Zones](https://docs.openshift.com/container-platform/4.12/installing/installing_aws/installing-aws-localzone.html#installation-cloudformation-vpc-localzone_installing-aws-localzone)
+- template-vpc.yam: [CloudFormation template for the VPC that uses AWS Local Zones](https://docs.openshift.com/container-platform/4.12/installing/installing_aws/installing-aws-localzone.html#installation-cloudformation-vpc-localzone_installing-aws-localzone)
 - template-lz.yaml: [CloudFormation template for the subnet that uses AWS Local Zones](https://docs.openshift.com/container-platform/4.12/installing/installing_aws/installing-aws-localzone.html#installation-cloudformation-subnet-localzone_installing-aws-localzone)
 
 Create the VPC with CloudFormation Template:
@@ -83,11 +92,14 @@ $ aws cloudformation wait stack-create-complete --stack-name ${STACK_VPC}
 $ aws cloudformation describe-stacks --stack-name ${STACK_VPC}
 ~~~
 
-> TODO add image VPC Cfn Stack
+![ocp-aws-localzones-step1-cfn-vpc](https://github.com/mtulio/mtulio.labs/assets/3216894/08c01da3-416b-4a70-a253-a931086ea978)
+
+<p><center>Figure-4: CloudFormation Stack for VPC</center></p>
+
 
 ### Step 2.  Create the public subnet in the AWS Local Zone
 
-Create the subnet on Local Zone (example New York [us-east-1-nyc-1a]), and set the variables used to Local Zones.
+Create the subnet on Local Zone (New York [us-east-1-nyc-1a]), and set the variables used to Local Zones.
 
 ~~~bash
 $ export STACK_LZ=${CLUSTER_NAME}-lz-nyc-1a
@@ -102,7 +114,7 @@ $ export VPC_RTB_PUB=$(aws cloudformation describe-stacks \
   | jq -r '.Stacks[0].Outputs[] | select(.OutputKey=="PublicRouteTableId").OutputValue' )
 ~~~
 
-Enable the Zone Group and create the resources.
+Enable the Zone Group and create the CloudFormation Stack for Local Zone subnets:
 
 ~~~bash
 $ aws ec2 modify-availability-zone-group \
@@ -124,11 +136,23 @@ $ aws cloudformation wait stack-create-complete --stack-name ${STACK_LZ}
 $ aws cloudformation describe-stacks --stack-name ${STACK_LZ}
 ~~~
 
+![ocp-aws-localzones-step2-cfn-subnet-nyc-1a](https://github.com/mtulio/mtulio.labs/assets/3216894/e6e25f4f-b76d-4214-8639-9a9dc176ad5f)
 
-The network is ready! Now you can set up the OpenShift installer to create a cluster in the existing VPC.
-3.  Setup the Install configuration
-To create the install configuration, you set the Subnet IDs for all zones in the region excluding Local Zone's subnets.
-First, collect the subnet Ids from the CloudFormation templates outputs:
+<p><center>Figure-5: CloudFormation Stack for Local Zone subnet in NYC</center></p>
+
+The network setup is ready! Now you can set up the OpenShift installer to create a cluster in the existing VPC.
+
+![ocp-aws-localzones-step2-subnets](https://github.com/mtulio/mtulio.labs/assets/3216894/7f1ba097-95c6-4022-92a6-9714c52b5928)
+
+<p><center>Figure-6: VPC Subnets</center></p>
+
+### Step 3. Setup the Install configuration
+
+To install OCP in existing subnets, the field `platform.aws.subnets` must be set with the subnets IDs created in the last section.
+
+Running the following commands the variable `SUBNETS` will be populated with the output values of CloudFormation stacks:
+
+- Public and Private subnets:
 
 ~~~bash
 $ mapfile -t SUBNETS < <(aws cloudformation describe-stacks \
@@ -140,8 +164,18 @@ $ mapfile -t -O "${#SUBNETS[@]}" SUBNETS < <(aws cloudformation describe-stacks 
   | jq -r '.Stacks[0].Outputs[1].OutputValue' | tr ',' '\n')
 ~~~
 
+- Local Zone subnets:
 
-Then, create the install-config.yaml manifest (adapt it according your environment):
+~~~bash
+# Set the SUBNET_ID to be used later
+export SUBNET_ID=$(aws cloudformation describe-stacks --stack-name "${STACK_LZ}" \
+  | jq -r .Stacks[0].Outputs[0].OutputValue)
+
+# Append the Local Zone subnet to the subnet ID list
+SUBNETS+=(${SUBNET_ID})
+~~~
+
+Lastly, create the `install-config.yaml` with the subnets:
 
 ~~~bash
 $ cat <<EOF > ${PWD}/install-config.yaml
@@ -161,210 +195,231 @@ sshKey: |
 EOF
 ~~~
 
-Create the manifests.
+All 7 subnets, including Local Zone, must be defined:
+
+~~~bash
+$ grep -A 7 subnets ${PWD}/install-config.yaml
+~~~
+
+**Optionally**, create the manifests to check the generated MachineSet manifests:
+
+> The installer will automatically discover the supported instance type for each Local Zone and create the MachineSet manifests. The Maximum Transmission Unit (MTU) for the cluster network will automatically be adjusted according to the network plugin set on install-config.yaml.
 
 ~~~bash
 $ ./openshift-install create manifests
+$ ls -l manifests/cluster-network-*
+$ ls -l openshift/99_openshift-cluster-api_worker-machineset-*
 ~~~
 
-Set the maximum transmission unit (MTU) for the cluster network. Local Zones require 1300 MTU to communicate between nodes in Local Zone nodes and Availability Zones. Decrease the overhead of the cluster network plugin as OVN-Kubernetes requires 100 bytes (per our example). Learn more about the MTU at How Local Zones work.
+### Step 4.  Create the OpenShift cluster
 
-~~~bash
-$ cat <<EOF > manifests/cluster-network-03-config.yml
-apiVersion: operator.openshift.io/v1
-kind: Network
-metadata:
-  name: cluster
-spec:
-  defaultNetwork:
-    ovnKubernetesConfig:
-      mtu: 1200
-EOF
-~~~
-
-### Step 4.  Create the Machine Set manifest
-
-Finally, set the required variables to create the Machine Sets on the Local Zone subnets:
-
-- Check the available types using: aws ec2 describe-instance-type-offerings [..]
-
-~~~bash
-$ export INSTANCE_TYPE="c5d.2xlarge"
-
-# discovery values from manifests created by the Installer:
-$ export AMI_ID=$(grep ami openshift/99_openshift-cluster-api_worker-machineset-0.yaml \
-  | tail -n1 | awk '{print$2}')
-
-$ export CLUSTER_ID="$(awk '/infrastructureName: / {print $2}' manifests/cluster-infrastructure-02-config.yml)"
-
-# get the Local Zone subnetID
-$ export SUBNET_ID=$(aws cloudformation describe-stacks --stack-name "${STACK_LZ}" \
-  | jq -r .Stacks[0].Outputs[0].OutputValue)
-~~~
-
-
-- Create the Machine Set.
-
-~~~bash
-$ cat <<EOF > openshift/99_openshift-cluster-api_worker-machineset-nyc1.yaml
-apiVersion: machine.openshift.io/v1beta1
-kind: MachineSet
-metadata:
-  labels:
-    machine.openshift.io/cluster-api-cluster: ${CLUSTER_ID}
-  name: ${CLUSTER_ID}-edge-${ZONE_GROUP_NAME}a
-  namespace: openshift-machine-api
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      machine.openshift.io/cluster-api-cluster: ${CLUSTER_ID}
-      machine.openshift.io/cluster-api-machineset: ${CLUSTER_ID}-edge-${ZONE_GROUP_NAME}a
-  template:
-    metadata:
-      labels:
-        machine.openshift.io/cluster-api-cluster: ${CLUSTER_ID}
-        machine.openshift.io/cluster-api-machine-role: edge
-        machine.openshift.io/cluster-api-machine-type: edge
-        machine.openshift.io/cluster-api-machineset: ${CLUSTER_ID}-edge-${ZONE_GROUP_NAME}a
-    spec:
-      metadata:
-        labels:
-          machine.openshift.com/zone-type: local-zone
-          machine.openshift.com/zone-group: ${ZONE_GROUP_NAME}
-          node-role.kubernetes.io/edge: ""
-      taints:
-        - key: node-role.kubernetes.io/edge
-          effect: NoSchedule
-      providerSpec:
-        value:
-          ami:
-            id: ${AMI_ID}
-          apiVersion: machine.openshift.io/v1beta1
-          blockDevices:
-          - ebs:
-              volumeSize: 120
-              volumeType: gp2
-          credentialsSecret:
-            name: aws-cloud-credentials
-          deviceIndex: 0
-          iamInstanceProfile:
-            id: ${CLUSTER_ID}-worker-profile
-          instanceType: ${INSTANCE_TYPE}
-          kind: AWSMachineProviderConfig
-          placement:
-            availabilityZone: ${ZONE_GROUP_NAME}a
-            region: ${CLUSTER_REGION}
-          securityGroups:
-          - filters:
-            - name: tag:Name
-              values:
-              - ${CLUSTER_ID}-worker-sg
-          subnet:
-            id: ${SUBNET_ID}
-          publicIp: true
-          tags:
-          - name: kubernetes.io/cluster/${CLUSTER_ID}
-            value: owned
-          userDataSecret:
-            name: worker-user-data
-EOF
-~~~
-
-Review the Machine Set manifest file - openshift/99_openshift-cluster-api_worker-machineset-nyc1.yaml -  to be sure it has been populated with your environment correctly
-
-
-### Step 5.  Create the OpenShift cluster
-
-Create the cluster.
+Create the cluster:
 
 ~~~bash
 $ ./openshift-install create cluster
 ~~~
 
-The cluster should now be created. You can check the node object to confirm.
+Check the nodes created in AWS Local Zones, labeled with `node-role.kubernetes.io/edge`:
 
 ~~~bash
 $ export KUBECONFIG=$PWD/auth/kubeconfig
 $ oc get nodes -l node-role.kubernetes.io/edge
-NAME                                    STATUS   ROLES         AGE   VERSION
-ip-10-0-138-99.ec2.internal   Ready    edge,worker   29m   v1.25.4+77bec7a
+NAME                          STATUS   ROLES         AGE     VERSION
+ip-10-0-128-81.ec2.internal   Ready    edge,worker   4m46s   v1.26.3+b404935
 ~~~
 
-You also can check the machine created by the Machine Set:
+You can also check the machine created by Machineset added on install time:
 
 ~~~bash
-$ oc get machine  -n openshift-machine-api
-NAME                                                              PHASE     TYPE            REGION    ZONE                    AGE
-ocp-lz-2nnns-edge-us-east-1-nyc-1a-cw78g   Running   c5d.2xlarge   us-east-1   us-east-1-nyc-1a   93m
+$ oc get machines -l machine.openshift.io/cluster-api-machine-role=edge -n openshift-machine-api
+NAME                                        PHASE     TYPE          REGION      ZONE               AGE
+demo-lz-knlm2-edge-us-east-1-nyc-1a-f2lzd   Running   c5d.2xlarge   us-east-1   us-east-1-nyc-1a   12m
+~~~
+
+![ocp-aws-localzones-step4-ocp-nodes-ec2](https://github.com/mtulio/mtulio.labs/assets/3216894/7d6c9c54-dc6e-41eb-84b4-7288533b7890)
+
+<p><center>Figure-7: OpenShift nodes created by the installer in AWS EC2 Console</center></p>
+
+## Extend an existing OpenShift cluster to new AWS Local Zones
+
+This step describes the Day 2 operation to extend the compute nodes to Local Zones in an existing OpenShift cluster, be sure the VPC running the cluster has enough CIDR blocks to create the subnet(s) for the desired Local Zone location.
+
+Refer to `Step 2` to create subnets in Local Zones.
+
+> Note: if the cluster wasn't installed with Local Zone subnets, the MTU for the cluster-wide network must be adjusted manually. See the OpenShift documentation for more information.
+
+![ocp-aws-localzones-step5-cfn-subnet-bue-1a](https://github.com/mtulio/mtulio.labs/assets/3216894/486f4361-d8c3-4810-b5bb-0fd7a6c0fc46)
+
+<p><center>Figure-8: CloudFormation Stack for Local Zone subnet in us-east-1-bue-1a</center></p>
+
+Finally, to create nodes using the new zone, you must manually create the MachineSet manifest. The steps below show how to check the instance offered by the zone, and create the MachineSet manifest based on the existing one in the Local Zone of Buenos Aires(`us-east-1-bue-1a`):
+
+> Currently the Local Zone of Buenos Aires (AR) does not support Application Load Balancers, it will be used on the deployments over the next sections to expose applications directly to the node.
+
+- Check and export the instance type offered by the Zone:
+
+~~~bash
+$ aws ec2 describe-instance-type-offerings \
+    --location-type availability-zone \
+    --filters Name=location,Values=${AWS_REGION}-bue-1a \
+    --region ${AWS_REGION} \
+    --query 'InstanceTypeOfferings[*].InstanceType' --output text
+t3.xlarge   c5.4xlarge
+t3.medium   c5.12xlarge
+c5.2xlarge  r5.2xlarge  m5.2xlarge
+g4dn.2xlarge
+
+$ export INSTANCE_BUE=m5.2xlarge
+~~~
+
+- Export and patch the manifest using the existing Machineset
+
+~~~bash
+# Discover and copy the nyc-1 machineset manifest
+$ BASE_MANIFEST=$(oc get machineset -n openshift-machine-api -o jsonpath='{range .items[*].metadata}{.name}{"\n"}{end}' | grep nyc-1)
+
+$ oc get machineset -n openshift-machine-api ${BASE_MANIFEST} -o yaml > machineset-lz-bue-1a.yaml
+
+# replace the subnet ID from NYC to BUE
+sed -si "s/${SUBNET_ID}/${SUBNET_ID_BUE}/g" machineset-lz-bue-1a.yaml
+
+# replace the zone reference from NYC to BUE
+sed -si "s/nyc-1/bue-1/g" machineset-lz-bue-1a.yaml
+
+# replace the instance type to a new one
+current_instance=$(oc get machineset -n openshift-machine-api ${BASE_MANIFEST} -o jsonpath='{.spec.template.spec.providerSpec.value.instanceType}')
+sed -si "s/${current_instance}/${INSTANCE_BUE}/g" machineset-lz-bue-1a.yaml
+
+# set the replicas to 0 to create a custom SG before launching the node
+sed -si "s/replicas: 1/replicas: 0/g" machineset-lz-bue-1a.yaml
+~~~
+
+- Create the Machineset:
+
+~~~bash
+$ oc create -f machineset-lz-bue-1a.yaml
+~~~
+
+- Considering the limitation of ALB in the zone us-east-1-bue-1a, the service running in this node will be reached directly from the internet. A dedicated security group will be created and attached to the node running in us-east-1-bue-1a:
+
+> Save the `SG_ID_BUE` to set the ingress rules on the next steps
+
+~~~bash
+$ INFRA_ID="$(oc get infrastructure cluster -o jsonpath='{.status.infrastructureName}')"
+$ SG_NAME_BUE=${INFRA_ID}-lz-ingress-bue-1
+$ SG_ID_BUE=$(aws ec2 create-security-group \
+    --group-name ${SG_NAME_BUE} \
+    --description "${SG_NAME_BUE}" \
+    --vpc-id ${VPC_ID} | jq -r .GroupId)
+~~~
+
+- Update the Machineset with the new security group:
+
+~~~bash
+$ export MCSET_BUE=$(oc get machineset -n openshift-machine-api -o jsonpath='{range .items[*].metadata}{.name}{"\n"}{end}' | grep bue-1)
+
+# Patch the MachineSet manifest adding the new Security Group
+$ oc patch machineset ${MCSET_BUE} -n openshift-machine-api --type=merge \
+  --patch "{
+    \"spec\":{
+      \"template\":{
+        \"spec\":{
+          \"providerSpec\":{
+            \"value\": {
+              \"securityGroups\":[{
+                \"filters\": [{
+                  \"name\": \"tag:Name\",
+                  \"values\":[\"${INFRA_ID}-worker-sg\",\"${INFRA_ID}-lz-ingress-bue-1\"]
+                }] }]}}}}}}"
+~~~
+
+- Scale the node and wait for the machine creation
+
+~~~bash
+$ oc scale --replicas=1 -n openshift-machine-api $MCSET_BUE
+$ oc get machines -n openshift-machine-api -l machine.openshift.io/cluster-api-machine-role=edge -w
+NAME                                        PHASE         TYPE          REGION      ZONE               AGE
+demo-lz-knlm2-edge-us-east-1-bue-1a-zd8zs   Provisioned   m5.2xlarge    us-east-1   us-east-1-bue-1a   8m47s
+demo-lz-knlm2-edge-us-east-1-nyc-1a-f2lzd   Running       c5d.2xlarge   us-east-1   us-east-1-nyc-1a   55m
 (...)
 ~~~
 
-## How to Extend an existing OpenShift cluster over AWS Local Zones
+> It can take some time to finish the provisioning by AWS, make sure the machine is in the Running phase before proceeding.
 
-To extend the compute nodes to Local Zones in an existing OpenShift cluster, be sure the VPC running the cluster has enough CIDR blocks to create the subnet(s) for the desired Local Zone location(s).
+All done, now the cluster is installed and running into two different Local Zones, New York (US) and Buenos Aires (Argentina).
 
-Refer to Step 2 in the previous section to extend your existing VPC creating nodes in Local Zones.
+![ocp-aws-localzones-step5-ec2-bue-1a](https://github.com/mtulio/mtulio.labs/assets/3216894/545342e3-8298-41d8-be4a-7542ab4d9e16)
 
-Adjust the MTU of the cluster network in existing clusters according to your network plugin per RHOCP4: getting 'TLS handshake timeout' pulling images from AWS Local Zones workers.  
+<p><center>Figure-9: OpenShift nodes running in AWS Local Zones in EC2 Console</center></p>
 
-Create the public subnet on Local Zone as described in Step 2 in the previous section.
+## Deploy workloads in AWS Local Zones
 
-Next, enable the Zone group. Then, create the Local Zone subnet running the CloudFormation Template. Finally, create the Machine Set manifest, adapting to your existing cluster as per Step 4 in previous section.
+As described in the section "Step 1. Installing an OpenShift cluster with AWS Local Zones", there are a few use cases to run workloads in Local Zones. This post demonstrates how to take advantage of Local Zones by deploying a sample application and selecting workers running in Local Zones.
 
-~~~bash
-cat <<EOF > | oc create -f -
-apiVersion: machine.openshift.io/v1beta1
-kind: MachineSet
-(...)
-~~~
+Three deployments will be created:
 
-## Deploy user-workloads in AWS Local Zones
-
-As described in “How to Create an OpenShift cluster with AWS Local Zones at install time” section above, there are a few use cases to run workloads in Local Zones. We demonstrate how to take advantage of Local Zones by deploying a sample application and selecting workers running in Local Zones.
+- Application running in Local Zone NYC ingressing traffic using ALB Operator in the zone
+- Application running in the Region, ingress traffic using the default router
+- Application running in Local Zone Buenos Aires (Argentina) ingressing traffic directly to the node (at the current moment that zone does not support AWS Load Balancers)
 
 The compute nodes deployed in Local Zones have the following extra labels:
 
 ~~~bash
-machine.openshift.com/zone-type: local-zone
-machine.openshift.com/zone-group: us-east-1-nyc-1
+machine.openshift.io/zone-type: local-zone
+machine.openshift.io/zone-group: us-east-1-nyc-1
 node-role.kubernetes.io/edge: ""
 ~~~
 
-You must set the proper tolerations to `node-role.kubernetes.io/edge`, selecting the node according to your use case.
+You must set the tolerations to `node-role.kubernetes.io/edge`, selecting the node according to your use case.
 
-This example uses the `machine.openshift.com/zone-group` label to select the Local Zone node(s), creates the following deployment to create a sample application in the network border group of New York (us-east-1-nyc-1):
+This example uses the `machine.openshift.io/zone-group` label to select the Local Zone node(s), and creates the following deployment to create a sample application in the network border group of New York (us-east-1-nyc-1):
+
+- Create the namespace:
 
 ~~~bash
-cat << EOF | oc create -f -
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: lz-apps
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: lz-app-nyc-1
-  namespace: lz-apps
-spec:
-  selector:
-    matchLabels:
-      app: lz-app-nyc-1
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        app: lz-app-nyc-1
-        zoneGroup: ${ZONE_GROUP_NAME}
-    spec:
-      nodeSelector:
-        machine.openshift.com/zone-group: ${ZONE_GROUP_NAME}
+export APPS_NAMESPACE="localzone-apps"
+oc create namespace ${APPS_NAMESPACE}
+~~~
+
+- Create the function to create the deployments for each location:
+
+~~~bash
+
+function create_deployment() {
+    local zone_group=$1; shift
+    local app_name=$1; shift
+    local set_toleration=${1:-''}
+    local tolerations=''
+    
+    if [[ $set_toleration == "yes" ]]; then
+        tolerations='
       tolerations:
       - key: "node-role.kubernetes.io/edge"
         operator: "Equal"
         value: ""
-        effect: "NoSchedule"
+        effect: "NoSchedule"'
+    fi
+    
+    cat << EOF | oc create -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${app_name}
+  namespace: ${APPS_NAMESPACE}
+spec:
+  selector:
+    matchLabels:
+      app: ${app_name}
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ${app_name}
+        zoneGroup: ${zone_group}
+    spec:
+      nodeSelector:
+        machine.openshift.io/zone-group: ${zone_group}
+${tolerations}
       containers:
         - image: openshift/origin-node
           command:
@@ -376,12 +431,61 @@ spec:
           name: echoserver
           ports:
             - containerPort: 8080
----
+EOF
+}
+~~~
+
+- Create the application for each location:
+
+~~~bash
+# App running in a node in New York
+create_deployment "${AWS_REGION}-nyc-1" "app-nyc-1" "yes"
+
+# App running in a node in Buenos Aires
+create_deployment "${AWS_REGION}-bue-1" "app-bue-1" "yes"
+~~~
+
+Lastly, to deploy the application in the nodes running in the Region (regular zones), we will pick one node and set it up:
+
+~~~bash
+NODE_NAME=$(oc get nodes -l node-role.kubernetes.io/worker='',topology.kubernetes.io/zone=${AWS_REGION}a -o jsonpath='{.items[0].metadata.name}')
+oc label node ${NODE_NAME} machine.openshift.io/zone-group=${AWS_REGION}
+
+# App running in a node in the regular zones
+create_deployment "${AWS_REGION}" "app-default"
+~~~
+
+All set, all applications must be running into different locations:
+
+~~~bash
+$ oc get pods -o wide 
+NAME                           READY   STATUS    RESTARTS   AGE     IP            NODE                          NOMINATED NODE   READINESS GATES
+app-bue-1-689b95f4c4-jf6fb     1/1     Running   0          5m4s    10.131.2.6    ip-10-0-156-17.ec2.internal   <none>           <none>
+app-default-857b5dc59f-r8cst   1/1     Running   0          75s     10.130.2.24   ip-10-0-51-38.ec2.internal    <none>           <none>
+app-nyc-1-54ffd5c89b-bbhqp     1/1     Running   0          5m31s   10.131.0.6    ip-10-0-128-81.ec2.internal   <none>           <none>
+
+ $ oc get pods --show-labels
+NAME                           READY   STATUS    RESTARTS   AGE     LABELS
+app-bue-1-689b95f4c4-jf6fb     1/1     Running   0          5m16s   app=app-bue-1,pod-template-hash=689b95f4c4,zoneGroup=us-east-1-bue-1
+app-default-857b5dc59f-r8cst   1/1     Running   0          87s     app=app-default,pod-template-hash=857b5dc59f,zoneGroup=us-east-1
+app-nyc-1-54ffd5c89b-bbhqp     1/1     Running   0          5m43s   app=app-nyc-1,pod-template-hash=54ffd5c89b,zoneGroup=us-east-1-nyc-1
+~~~
+
+## Create Ingress for each deployment
+
+It's time to create the ingress for each location.
+
+When this blog has been written, Local Zones has limited support of AWS Load Balancers, supporting only AWS Application Load Balancer (ALB) with limited locations. To expose your application to end users with ALB, you must create, when supported, a custom ingress for each location by using the [AWS Application Load Balancer (ALB) Operator](https://docs.openshift.com/container-platform/4.12/networking/aws_load_balancer_operator/understanding-aws-load-balancer-operator.html). Only NYC Local Zone supports ALB, for sake of simplicity, this example will expose the node port directly to the internet in the app running in the node on Buenos Aires (us-east-1-bue-1a) zone.
+
+### Ingress for Availability Zone's app
+
+~~~bash
+cat << EOF | oc create -f -
 apiVersion: v1
 kind: Service 
 metadata:
-  name:  lz-app-nyc-1 
-  namespace: lz-apps
+  name: app-default
+  namespace: ${APPS_NAMESPACE}
 spec:
   ports:
     - port: 80
@@ -389,29 +493,73 @@ spec:
       protocol: TCP
   type: NodePort
   selector:
-    app: lz-app-nyc-1
+    app: app-default
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: app-default
+  namespace: ${APPS_NAMESPACE}
+spec:
+  port:
+    targetPort: 8080 
+  to:
+    kind: Service
+    name: app-default
 EOF
 ~~~
 
-When we wrote this blog, Local Zones only supports AWS Application Load Balancer. To expose your application to end users, you create a custom ingress for each location by using the [AWS Application Load Balancer (ALB) Operator](https://docs.openshift.com/container-platform/4.12/networking/aws_load_balancer_operator/understanding-aws-load-balancer-operator.html).
+- Export the `APP_HOST_AZ` address for that location:
+
+```bash
+APP_HOST_AZ="$(oc get route.route.openshift.io/app-default -o jsonpath='{.status.ingress[0].host}')"
+```
+
+### Ingress for NYC (New York) Local Zone app
 
 Create the ALB Operator following the steps listed in [Installing the AWS Load Balancer Operator](https://docs.openshift.com/container-platform/4.12/networking/aws_load_balancer_operator/install-aws-load-balancer-operator.html), then [Create the ALB Controller](https://docs.openshift.com/container-platform/4.12/networking/aws_load_balancer_operator/create-instance-aws-load-balancer-controller.html).
 
-Next, create the custom Ingress using Local Zone subnet.
+> Make sure the ALB Controllers are running before proceeding
+
+```bash
+$ oc get pods -n aws-load-balancer-operator 
+NAME                                                             READY   STATUS    RESTARTS   AGE
+aws-load-balancer-controller-cluster-567bc99b68-rnkjn            1/1     Running   0          43s
+aws-load-balancer-controller-cluster-567bc99b68-s7w4z            1/1     Running   0          43s
+aws-load-balancer-operator-controller-manager-7674db45d6-hmswz   2/2     Running   0          90s
+```
+
+Next, create the custom Ingress using Local Zone subnet:
+
+> Note: the variable `SUBNET_ID` must be set with the NYC subnet ID
 
 ~~~bash
-cat << EOF | oc create -f -
+$ cat << EOF | oc create -f -
+apiVersion: v1
+kind: Service 
+metadata:
+  name: app-nyc-1
+  namespace: ${APPS_NAMESPACE}
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  type: NodePort
+  selector:
+    app: app-nyc-1
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-lz-nyc-1
-  namespace: lz-apps
+  namespace: ${APPS_NAMESPACE}
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: instance
     alb.ingress.kubernetes.io/subnets: ${SUBNET_ID}
   labels:
-    zoneGroup: ${ZONE_GROUP_NAME}
+    zoneGroup: us-east-1-nyc-1
 spec:
   ingressClassName: cloud
   rules:
@@ -421,7 +569,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: lz-app-nyc-1
+                name: app-nyc-1
                 port:
                   number: 80
 EOF
@@ -429,63 +577,278 @@ EOF
 
 Wait for the Load Balancer to get created.
 
-> TODO add images from AWS Console: Load Balancer, TG
+![ocp-aws-localzones-step7-alb-nyc](https://github.com/mtulio/mtulio.labs/assets/3216894/7f4f1b0f-5470-403e-b93d-bdefabd6f1c1)
 
-Once created, discover the ALB URL and test it.
+<p><center>Figure-10: Load Balancer created for the ingress using NYC Local Zone subnet</center></p>
+
+![ocp-aws-localzones-step7-alb-tg-nyc](https://github.com/mtulio/mtulio.labs/assets/3216894/15cd5adb-d7d4-42c3-a1dc-249658667ebd)
+
+<p><center>Figure-11: Target Group added the Local Zone node as a target</center></p>
+
+
+Once created, discover the load balancer host address and test it.
 
 ~~~bash
-$ HOST=$(oc get ingress -n lz-apps ingress-lz-nyc-1 --template='{{(index .status.loadBalancer.ingress 0).hostname}}')
+$ APP_HOST_NYC=$(oc get ingress -n ${APPS_NAMESPACE} ingress-lz-nyc-1 --template='{{(index .status.loadBalancer.ingress 0).hostname}}')
 
-$ curl $HOST
+$ curl $APP_HOST_NYC
 GET / HTTP/1.1
-X-Forwarded-For: 179.181.81.124
-X-Forwarded-Proto: http
-X-Forwarded-Port: 80
-Host: k8s-lzapps-ingressl-13226f2551-de.us-east-1.elb.amazonaws.com
-X-Amzn-Trace-Id: Root=1-63e18147-1532a244542b04bc75ffd473
-User-Agent: curl/7.61.1
-Accept: */*
+(...)
 ~~~
 
-To benchmark the performance, review the network time to connect between different locations:
+
+### Ingress for BUE (Buenos Aires) Local Zone app
+
+Create an ingressController running in the Buenos Aires Local Zone node using HostNetwork:
 
 ~~~bash
-# [1] NYC (outside AWS backbone)
-$ curl -s http://ip-api.com/json/$(curl -s ifconfig.me) |jq -r '[.city, .countryCode]'
-[  "North Bergen",   "US" ]
-$ curl -sw "%{time_namelookup}   %{time_connect}     %{time_starttransfer}    %{time_total}\n" -o /dev/null $HOST
-0.001452   0.004079     0.008914    0.009830
-
-# [2] Within the Region (master nodes)
-$ oc debug node/$(oc get nodes -l node-role.kubernetes.io/master -o jsonpath={'.items[0].metadata.name'}) -- chroot /host /bin/bash -c "\
-hostname; \
-curl -s http://ip-api.com/json/\$(curl -s ifconfig.me) |jq -r '[.city, .countryCode]';\
-curl -sw \"%{time_namelookup}   %{time_connect}     %{time_starttransfer}    %{time_total}\\n\" -o /dev/null $HOST"
-ip-10-0-54-118
-[ "Ashburn",  "US" ]
-0.002068   0.010196     0.019962    0.020985
-
-# [3] London (outside AWS backbone)
-$ curl -s http://ip-api.com/json/$(curl -s ifconfig.me) |jq -r '[.city, .countryCode]'
-[ "London", "GB" ]
-$ curl -sw "%{time_namelookup}   %{time_connect}     %{time_starttransfer}    %{time_total}\n" -o /dev/null $HOST
-0.003332   0.099921     0.197535    0.198802
-
-# [4] Brazil
-$ curl -s http://ip-api.com/json/$(curl -s ifconfig.me) |jq -r '[.city, .countryCode]'
-[ "Florianópolis", "BR" ]
-$ curl -sw "%{time_namelookup}   %{time_connect}     %{time_starttransfer}    %{time_total}\n" -o /dev/null $HOST
-0.022869   0.187408     0.355456    0.356435
+$ cat << EOF | oc create -f -
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: ingress-lz-bue-1
+  namespace: openshift-ingress-operator
+  labels:
+    zoneGroup: us-east-1
+spec:
+  endpointPublishingStrategy:
+    type: HostNetwork
+  replicas: 1
+  domain: apps-bue1.${CLUSTER_NAME}.${CLUSTER_BASEDOMAIN}
+  nodePlacement:
+    nodeSelector:
+      matchLabels:
+        machine.openshift.io/zone-group: us-east-1-bue-1
+    tolerations:
+      - key: "node-role.kubernetes.io/edge"
+        operator: "Equal"
+        value: ""
+        effect: "NoSchedule"
+  routeSelector:
+    matchLabels:
+      type: sharded
+EOF
 ~~~
 
-The total time to connect, in seconds, from the client in NYC (outside AWS) to OpenShift edge node running in Local Zone was more than 2x faster compared with the client running in the regular zones.
+Expose the route:
 
-| Server / Client | [1]NYC/US | [2]AWS Region/use1 | [3]London/UK | [4]Brazil |
-| -- | -- | -- | -- | -- | -- |
-| us-east-1-nyc-1a | 0.004079 | 0.010196 | 0.099921 | 0.187408 |
+~~~bash
+$ cat << EOF | oc create -f -
+apiVersion: v1
+kind: Service 
+metadata:
+  name: app-bue-1
+  namespace: ${APPS_NAMESPACE}
+  labels:
+    zoneGroup: us-east-1-bue-1
+    app: app-bue-1
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  type: NodePort
+  selector:
+    app: app-bue-1
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: app-bue-1
+  namespace: ${APPS_NAMESPACE}
+  labels:
+    type: sharded
+spec:
+  host: app-bue-1.apps-bue1.${CLUSTER_NAME}.${CLUSTER_BASEDOMAIN}
+  port:
+    targetPort: 8080 
+  to:
+    kind: Service
+    name: app-bue-1
+EOF
+~~~
 
+Finally, patch the EC2 Security Group with rules allowing traffic through HTTP(80) and HTTPS(442) used by the new router:
+
+~~~bash
+$ aws ec2 authorize-security-group-ingress \
+    --group-id $SG_ID_BUE \
+    --protocol tcp \
+    --port 80 \
+    --cidr "0.0.0.0/0"
+
+$ aws ec2 authorize-security-group-ingress \
+    --group-id $SG_ID_BUE \
+    --protocol tcp \
+    --port 443 \
+    --cidr "0.0.0.0/0"
+~~~
+
+Discover and set the Buenos Aires' ingress address:
+
+~~~bash
+$ APP_HOST_BUE="$(oc get route.route.openshift.io/app-bue-1 -o jsonpath='{.status.ingress[0].host}')"
+
+$ IP_HOST_BUE="$(oc get nodes -l topology.kubernetes.io/zone=us-east-1-bue-1a -o json | jq -r '.items[].status.addresses[] | select (.type=="ExternalIP").address')"
+
+$ curl -H "Host: $APP_HOST_BUE" http://$IP_HOST_BUE
+~~~
+
+> Note: DNS config: the controller is not adding the DNSes to the public zone for the custom ingress controller. How DNS creates RR automatically for the sharded routers which don't use service LB, but HostNetwork with public IP address on the host interface?
+
+## Benchmark the applications
+
+As commented at the begging of this post, we'll test each application endpoint from different locations on the internet, some are closer to the metropolitan regions located in the Local Zone, so we'll be able to measure the network benefits of using edge compute pools in OpenShift.
+
+We will run simple tests creating a few requests from different clients, extracting the [`curl` variables writing it out](https://curl.se/docs/manpage.html#-w) to the console.
+
+
+Prepare the script `curl.sh` to test on each location:
+
+~~~bash
+$ echo "
+#!/usr/bin/env bash
+echo \"# Client Location: \"
+curl -s http://ip-api.com/json/\$(curl -s ifconfig.me) |jq -r '[.city, .countryCode]'
+
+run_curl() {
+  echo -e \"time_namelookup\\t time_connect \\t time_starttransfer \\t time_total\"
+  for idx in \$(seq 1 5); do
+    curl -sw \"%{time_namelookup} \\t %{time_connect} \\t %{time_starttransfer} \\t\\t %{time_total}\\n\" \
+    -o /dev/null -H \"Host: \$1\" \${2:-\$1}
+  done
+}
+
+echo -e \"\n# Collecting request times to server running in AZs/Regular zones [endpoint ${APP_HOST_AZ}]\"
+run_curl ${APP_HOST_AZ}
+
+echo -e \"\n# Collecting request times to server running in Local Zone NYC [endpoint ${APP_HOST_NYC}]\"
+run_curl ${APP_HOST_NYC}
+
+echo -e \"\n# Collecting request times to server running in Local Zone BUE [endpoint ${APP_HOST_BUE}]\"
+run_curl ${APP_HOST_BUE} ${IP_HOST_BUE}
+" > curl.sh
+~~~
+
+Copy and run `curl.sh` to the clients:
+
+- Client located in the region of US/New York:
+
+~~~bash
+$ bash curl.sh 
+# Client Location: 
+["North Bergen", "US"]
+
+# Collecting request times to server running in AZs/Regular zones [endpoint app-default-localzone-apps.apps.demo-lz.devcluster.openshift.com]
+time_namelookup  time_connect    time_starttransfer      time_total
+0.010444         0.018078        0.031563                0.032449
+0.012000         0.019141        0.030801                0.031725
+0.000777         0.007918        0.019087                0.019860
+0.001437         0.008690        0.020179                0.020955
+0.005015         0.011915        0.023527                0.024309
+
+# Collecting request times to server running in Local Zone NYC [endpoint k8s-localzon-ingressl-573f917a81-716983909.us-east-1.elb.amazonaws.com]
+time_namelookup  time_connect    time_starttransfer      time_total
+0.002986         0.005248        0.009702                0.010571
+0.001368         0.003183        0.006447                0.007270
+0.001100         0.002503        0.005711                0.006586
+0.003174         0.004643        0.007955                0.008725
+0.003144         0.004601        0.007663                0.008500
+
+# Collecting request times to server running in Local Zone BUE [endpoint app-bue-1.apps-bue1.demo-lz.devcluster.openshift.com]
+time_namelookup  time_connect    time_starttransfer      time_total
+0.000026         0.141142        0.284566                0.285606
+0.000027         0.141474        0.284454                0.285362
+0.000025         0.141334        0.284213                0.285045
+0.000023         0.141085        0.283620                0.284515
+0.000026         0.141586        0.284625                0.285490
+~~~
+
+- Client located in the region of UK/London:
+
+~~~bash
+$ bash curl.sh
+# Client Location: 
+["Enfield", "GB"]
+
+# Collecting request times to server running in AZs/Regular zones [endpoint app-default-localzone-apps.apps.demo-lz.devcluster.openshift.com]
+time_namelookup  time_connect    time_starttransfer      time_total
+0.014856         0.096285        0.181679                0.182629
+0.001565         0.079669        0.162386                0.163355
+0.001891         0.081879        0.165896                0.166834
+0.001465         0.080108        0.163756                0.164491
+0.001224         0.081282        0.165828                0.166998
+
+# Collecting request times to server running in Local Zone NYC [endpoint k8s-localzon-ingressl-573f917a81-716983909.us-east-1.elb.amazonaws.com]
+time_namelookup  time_connect    time_starttransfer      time_total
+0.002339         0.092894        0.184171                0.185058
+0.001506         0.085278        0.167627                0.168613
+0.001176         0.083452        0.167570                0.168474
+0.001483         0.092990        0.186173                0.186859
+0.001130         0.083462        0.167462                0.168527
+
+# Collecting request times to server running in Local Zone BUE [endpoint app-bue-1.apps-bue1.demo-lz.devcluster.openshift.com]
+time_namelookup  time_connect    time_starttransfer      time_total
+0.000046         0.229893        0.462351                0.463439
+0.000030         0.233715        0.468338                0.469316
+0.000057         0.230159        0.462013                0.463272
+0.000041         0.230470        0.462181                0.463116
+0.000044         0.228971        0.459642                0.460627
+~~~
+
+- Client located in the region of Brazil/South:
+
+~~~bash
+$ bash curl.sh
+# Client Location: 
+["Florianópolis", "BR"]
+
+# Collecting request times to server running in AZs/Regular zones [endpoint app-default-localzone-apps.apps.demo-lz.devcluster.openshift.com]
+time_namelookup time_connect time_starttransfer time_total
+0.022768        0.172481     0.324897           0.326504
+0.024175        0.178215     0.337317           0.338611
+0.029904        0.183622     0.338799           0.340016
+0.016936        0.172481     0.331656           0.333060
+0.023056        0.174012     0.332869           0.333940
+
+# Collecting request times to server running in Local Zone NYC [endpoint k8s-localzon-ingressl-573f917a81-716983909.us-east-1.elb.amazonaws.com]
+time_namelookup time_connect time_starttransfer time_total
+0.023081        0.182175     0.339818           0.340769
+0.022908        0.187502     0.353711           0.354144
+0.024140        0.181430     0.342511           0.343637
+0.016736        0.175075     0.337191           0.338269
+0.017669        0.180589     0.342865           0.343365
+
+# Collecting request times to server running in Local Zone BUE [endpoint app-bue-1.apps-bue1.demo-lz.devcluster.openshift.com]
+time_namelookup time_connect time_starttransfer time_total
+0.000016        0.044052     0.090594           0.091382
+0.000018        0.043565     0.090848           0.091869
+0.000015        0.046529     0.092182           0.092997
+0.000019        0.043899     0.089382           0.090326
+0.000016        0.044163     0.089726           0.090368
+
+~~~
+
+Aggregating the results:
+
+![ocp-aws-localzones-step8-aggregated-results](https://github.com/mtulio/mtulio.labs/assets/3216894/9250fb62-fd99-4c31-9d77-178c82e38cb7)
+
+<p><center>Figure-12: Average connect and total time with slower points based on the baseline (fastest)</center></p>
+
+The total time to connect, in milliseconds, from the client in NYC (outside AWS) to the OpenShift edge node running in Local Zone was ~66% faster than the server running in the regular zones. It's also worth mentioning that there are improvements in clients accessing from different countries, looking at the results from the client in Brazil decreased by more than 100% of the total request time when accessing the Buenos Aires server, instead of going to the Region due to the geographic proximity of those locations.
+
+![ocp-aws-localzones-step8-nyc](https://github.com/mtulio/mtulio.labs/assets/3216894/85c059f3-cfe5-4381-a4b4-fba7cce976d2)
+
+<p><center>Figure-13: Client in NYC getting better experience accessing the NYC Local Zone, than the app in the region</center></p>
 
 ## Summary
 
 OpenShift provides a platform for easy deployment, scaling, and management of containerized applications across the hybrid cloud including AWS. Using OpenShift with AWS Local Zones provides numerous benefits for organizations. It allows for lower latency and improved network performance as Local Zones are physically closer to end users, which enhances the overall user experience and reduces downtime. The combination of OpenShift and AWS Local Zones provides a flexible and scalable solution that enables organizations to modernize their applications and meet the demands of their customers and users; 1) improving application performance and user experience, 2) hosting resources in specific geographic locations reducing overall cost and 3) providing regulated industries with a way to meet data residency requirements.
 
+
+## Categories
+
+- OpenShift 4
+- Edge
+- AWS
+- How-tos

--- a/docs/blogs/ocp-aws-local-zones/ocp-aws-local-zones-413.md
+++ b/docs/blogs/ocp-aws-local-zones/ocp-aws-local-zones-413.md
@@ -1,0 +1,491 @@
+# Extending Red Hat OpenShift Container Platform to AWS Local Zones
+
+> Authors: Marcos Entenza Garcia Marco Braga Fatih Nar
+
+## Overview
+
+In Red Hat OpenShift Container Platform 4.12, we introduced the ability to extend cluster formation into Amazon Web Services (AWS) Local Zones in Red Hat OpenShift. In this post, we present how to deploy OpenShift compute nodes in Local Zones at cluster creation time, where the OpenShift Installer creates compute nodes in configured Local Zones. In addition, we share how the cluster administrator adds compute nodes in Local Zones to an existing OpenShift cluster.
+
+Before diving into deploying OpenShift with Local Zones, let's review what Local Zones are.
+
+Local Zones allow you to use select AWS services, like compute and storage services, closer to more end-users, providing them with very low latency access to the applications running locally. Local Zones are fully-owned and managed by AWS with no-upfront commitment and no hardware purchase or lease required. In addition, Local Zones connect to the parent AWS cloud region via AWS' redundant and very high bandwidth private network, providing applications running in Local Zones fast, secure, and seamless access to the rest of AWS services.
+
+![AWS Infrastructure Continuum](https://github.com/mtulio/mtulio.labs/assets/3216894/b4e68d09-bc65-40f4-91aa-1f1cbdea06e6)
+
+<p><center>Figure-1 AWS Infrastructure Continuum</center></p>
+
+
+Using OpenShift with Local Zones, application developers and service consumers will reap the following benefits:
+
+- Improving application performance and user experience by hosting resources closer to the user, Local Zones reduce the time it takes for data to travel over the network, resulting in faster load times and more responsive applications. This is especially important for applications, such as video streaming or online gaming that require low-latency performance and real-time data access.
+- Hosting resources in specific geographic locations leads to cost savings, whereby customers avoid high costs associated with data transfer charges, such as cloud egress charges, which is a significant business expense, when large volumes of data is moved between regions in the case of image, graphics, and video related applications). 
+- Provide healthcare, government agencies, financial institutions, and other regulated industries a way to meet data residency requirements by hosting data and applications in specific locations to comply with regulatory laws and mandates.
+
+Let's walk through the steps to install an OpenShift cluster in an existing virtual private cloud (VPC) in the US Virginia (us-east-1) region by creating a Local Zone subnet, OpenShift Machine Set manifests, and automatically launch worker nodes during the installation. This diagram below shows what gets created:
+
+- An standard OpenShift Cluster is installed in us-east-1 with three Control Plane nodes and three Compute nodes
+- One "edge" Compute node runs in the Local Zone subnet in the New York metropolitan region
+- One Application Load Balancer exposes the sample application running in the Local Zone worker node
+
+![aws-local-zones-diagram-blog-hc drawio](https://github.com/mtulio/mtulio.labs/assets/3216894/06d75201-82dd-4c13-963f-9850e8fc7d34)
+
+<p><center>Figure-2 OpenShift Cluster installed in us-east-1 extending nodes to Local Zone in New York</center></p>
+
+
+## Installing an OpenShift cluster with AWS Local Zones
+
+To deploy a new OpenShift cluster extending compute nodes in Local Zone subnets, you install a cluster in an existing VPC and create MachineSet manifests for the Installer.
+
+The installation process automatically creates tainted compute nodes with `NoSchedule.` This allows the administrator to choose workloads to run in each remote location, without needing additional steps to isolate the applications.
+
+Once the cluster is installed, the label node-role.kubernetes.io/edge is set for each node located in the Local Zones, along with the regular node-role.kubernetes.io/worker.
+
+Note the following considerations when deploying a cluster in AWS Local Zones:
+
+- The Maximum Transmission Unit (MTU) between an Amazon EC2 instance in a Local Zone and an Amazon EC2 instance in the Region is 1300. This causes the cluster-wide network MTU to change according to the network plugin that is used on the deployment.
+- Network resources such as Network Load Balancer (NLB), Classic Load Balancer, and Nat Gateways are not supported in AWS Local Zones.
+- The AWS Elastic Block Storage (EBS) gp3 type volume is the default for node volumes and the default for the storage class set on AWS OpenShift clusters. This volume type is not globally available in Local Zone locations. By default, the nodes running in Local Zones are deployed with the gp2 EBS volume. The gp2-csi StorageClass must be set when creating workloads on Local Zone nodes.
+
+Install the following prerequisites before you proceed to the next step:
+
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+- [OpenShift Installer 4.12+](https://console.redhat.com/openshift/downloads)
+- [OpenShift CLI](https://console.redhat.com/openshift/downloads)
+
+### Step 1.  Create the VPC
+
+This section is optional. Create a VPC with your preferred customizations, as recommended in [Installing a cluster on AWS into an existing VPC](https://docs.openshift.com/container-platform/4.12/installing/installing_aws/installing-aws-vpc.html).
+Define the environment variables:
+
+~~~bash
+$ export CLUSTER_REGION=us-east-1
+$ export CLUSTER_NAME=ocp-lz
+~~~
+
+Download the following CloudFormation Templates with the following names:
+
+- template-vpc.yam : [CloudFormation template for the VPC that uses AWS Local Zones](https://docs.openshift.com/container-platform/4.12/installing/installing_aws/installing-aws-localzone.html#installation-cloudformation-vpc-localzone_installing-aws-localzone)
+- template-lz.yaml: [CloudFormation template for the subnet that uses AWS Local Zones](https://docs.openshift.com/container-platform/4.12/installing/installing_aws/installing-aws-localzone.html#installation-cloudformation-subnet-localzone_installing-aws-localzone)
+
+Create the VPC with CloudFormation Template:
+
+~~~bash
+$ export STACK_VPC=${CLUSTER_NAME}-vpc
+$ aws cloudformation create-stack --stack-name ${STACK_VPC} \
+     --template-body file://template-vpc.yaml \
+     --parameters \
+        ParameterKey=ClusterName,ParameterValue=${CLUSTER_NAME} \
+        ParameterKey=VpcCidr,ParameterValue="10.0.0.0/16" \
+        ParameterKey=AvailabilityZoneCount,ParameterValue=3 \
+        ParameterKey=SubnetBits,ParameterValue=12
+
+$ aws cloudformation wait stack-create-complete --stack-name ${STACK_VPC}
+$ aws cloudformation describe-stacks --stack-name ${STACK_VPC}
+~~~
+
+> TODO add image VPC Cfn Stack
+
+### Step 2.  Create the public subnet in the AWS Local Zone
+
+Create the subnet on Local Zone (example New York [us-east-1-nyc-1a]), and set the variables used to Local Zones.
+
+~~~bash
+$ export STACK_LZ=${CLUSTER_NAME}-lz-nyc-1a
+$ export ZONE_GROUP_NAME=${CLUSTER_REGION}-nyc-1
+
+# extract public and private subnetIds from VPC CloudFormation
+$ export VPC_ID=$(aws cloudformation describe-stacks \
+  --stack-name ${STACK_VPC} \
+  | jq -r '.Stacks[0].Outputs[] | select(.OutputKey=="VpcId").OutputValue' )
+$ export VPC_RTB_PUB=$(aws cloudformation describe-stacks \
+  --stack-name ${STACK_VPC} \
+  | jq -r '.Stacks[0].Outputs[] | select(.OutputKey=="PublicRouteTableId").OutputValue' )
+~~~
+
+Enable the Zone Group and create the resources.
+
+~~~bash
+$ aws ec2 modify-availability-zone-group \
+    --group-name "${ZONE_GROUP_NAME}" \
+    --opt-in-status opted-in
+
+$ aws cloudformation create-stack --stack-name ${STACK_LZ} \
+     --template-body file://template-lz.yaml \
+     --parameters \
+        ParameterKey=ClusterName,ParameterValue="${CLUSTER_NAME}" \
+        ParameterKey=VpcId,ParameterValue="${VPC_ID}" \
+        ParameterKey=PublicRouteTableId,ParameterValue="${VPC_RTB_PUB}" \
+        ParameterKey=LocalZoneName,ParameterValue="${ZONE_GROUP_NAME}a" \
+        ParameterKey=LocalZoneNameShort,ParameterValue="nyc-1a" \
+        ParameterKey=PublicSubnetCidr,ParameterValue="10.0.128.0/20"
+
+$ aws cloudformation wait stack-create-complete --stack-name ${STACK_LZ} 
+
+$ aws cloudformation describe-stacks --stack-name ${STACK_LZ}
+~~~
+
+
+The network is ready! Now you can set up the OpenShift installer to create a cluster in the existing VPC.
+3.  Setup the Install configuration
+To create the install configuration, you set the Subnet IDs for all zones in the region excluding Local Zone's subnets.
+First, collect the subnet Ids from the CloudFormation templates outputs:
+
+~~~bash
+$ mapfile -t SUBNETS < <(aws cloudformation describe-stacks \
+  --stack-name "${STACK_VPC}" \
+  | jq -r '.Stacks[0].Outputs[0].OutputValue' | tr ',' '\n')
+
+$ mapfile -t -O "${#SUBNETS[@]}" SUBNETS < <(aws cloudformation describe-stacks \
+  --stack-name "${STACK_VPC}" \
+  | jq -r '.Stacks[0].Outputs[1].OutputValue' | tr ',' '\n')
+~~~
+
+
+Then, create the install-config.yaml manifest (adapt it according your environment):
+
+~~~bash
+$ cat <<EOF > ${PWD}/install-config.yaml
+apiVersion: v1
+publish: External
+baseDomain: "<CHANGE_ME: example.com>"
+metadata:
+  name: "${CLUSTER_NAME}"
+platform:
+  aws:
+    region: ${CLUSTER_REGION}
+    subnets:
+$(for SB in ${SUBNETS[*]}; do echo "    - $SB"; done)
+pullSecret: '<CHANGE_ME: pull-secret-content>'
+sshKey: |
+  '<CHANGE_ME: ssh-keys>'
+EOF
+~~~
+
+Create the manifests.
+
+~~~bash
+$ ./openshift-install create manifests
+~~~
+
+Set the maximum transmission unit (MTU) for the cluster network. Local Zones require 1300 MTU to communicate between nodes in Local Zone nodes and Availability Zones. Decrease the overhead of the cluster network plugin as OVN-Kubernetes requires 100 bytes (per our example). Learn more about the MTU at How Local Zones work.
+
+~~~bash
+$ cat <<EOF > manifests/cluster-network-03-config.yml
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  defaultNetwork:
+    ovnKubernetesConfig:
+      mtu: 1200
+EOF
+~~~
+
+### Step 4.  Create the Machine Set manifest
+
+Finally, set the required variables to create the Machine Sets on the Local Zone subnets:
+
+- Check the available types using: aws ec2 describe-instance-type-offerings [..]
+
+~~~bash
+$ export INSTANCE_TYPE="c5d.2xlarge"
+
+# discovery values from manifests created by the Installer:
+$ export AMI_ID=$(grep ami openshift/99_openshift-cluster-api_worker-machineset-0.yaml \
+  | tail -n1 | awk '{print$2}')
+
+$ export CLUSTER_ID="$(awk '/infrastructureName: / {print $2}' manifests/cluster-infrastructure-02-config.yml)"
+
+# get the Local Zone subnetID
+$ export SUBNET_ID=$(aws cloudformation describe-stacks --stack-name "${STACK_LZ}" \
+  | jq -r .Stacks[0].Outputs[0].OutputValue)
+~~~
+
+
+- Create the Machine Set.
+
+~~~bash
+$ cat <<EOF > openshift/99_openshift-cluster-api_worker-machineset-nyc1.yaml
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: ${CLUSTER_ID}
+  name: ${CLUSTER_ID}-edge-${ZONE_GROUP_NAME}a
+  namespace: openshift-machine-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: ${CLUSTER_ID}
+      machine.openshift.io/cluster-api-machineset: ${CLUSTER_ID}-edge-${ZONE_GROUP_NAME}a
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: ${CLUSTER_ID}
+        machine.openshift.io/cluster-api-machine-role: edge
+        machine.openshift.io/cluster-api-machine-type: edge
+        machine.openshift.io/cluster-api-machineset: ${CLUSTER_ID}-edge-${ZONE_GROUP_NAME}a
+    spec:
+      metadata:
+        labels:
+          machine.openshift.com/zone-type: local-zone
+          machine.openshift.com/zone-group: ${ZONE_GROUP_NAME}
+          node-role.kubernetes.io/edge: ""
+      taints:
+        - key: node-role.kubernetes.io/edge
+          effect: NoSchedule
+      providerSpec:
+        value:
+          ami:
+            id: ${AMI_ID}
+          apiVersion: machine.openshift.io/v1beta1
+          blockDevices:
+          - ebs:
+              volumeSize: 120
+              volumeType: gp2
+          credentialsSecret:
+            name: aws-cloud-credentials
+          deviceIndex: 0
+          iamInstanceProfile:
+            id: ${CLUSTER_ID}-worker-profile
+          instanceType: ${INSTANCE_TYPE}
+          kind: AWSMachineProviderConfig
+          placement:
+            availabilityZone: ${ZONE_GROUP_NAME}a
+            region: ${CLUSTER_REGION}
+          securityGroups:
+          - filters:
+            - name: tag:Name
+              values:
+              - ${CLUSTER_ID}-worker-sg
+          subnet:
+            id: ${SUBNET_ID}
+          publicIp: true
+          tags:
+          - name: kubernetes.io/cluster/${CLUSTER_ID}
+            value: owned
+          userDataSecret:
+            name: worker-user-data
+EOF
+~~~
+
+Review the Machine Set manifest file - openshift/99_openshift-cluster-api_worker-machineset-nyc1.yaml -  to be sure it has been populated with your environment correctly
+
+
+### Step 5.  Create the OpenShift cluster
+
+Create the cluster.
+
+~~~bash
+$ ./openshift-install create cluster
+~~~
+
+The cluster should now be created. You can check the node object to confirm.
+
+~~~bash
+$ export KUBECONFIG=$PWD/auth/kubeconfig
+$ oc get nodes -l node-role.kubernetes.io/edge
+NAME                                    STATUS   ROLES         AGE   VERSION
+ip-10-0-138-99.ec2.internal   Ready    edge,worker   29m   v1.25.4+77bec7a
+~~~
+
+You also can check the machine created by the Machine Set:
+
+~~~bash
+$ oc get machine  -n openshift-machine-api
+NAME                                                              PHASE     TYPE            REGION    ZONE                    AGE
+ocp-lz-2nnns-edge-us-east-1-nyc-1a-cw78g   Running   c5d.2xlarge   us-east-1   us-east-1-nyc-1a   93m
+(...)
+~~~
+
+## How to Extend an existing OpenShift cluster over AWS Local Zones
+
+To extend the compute nodes to Local Zones in an existing OpenShift cluster, be sure the VPC running the cluster has enough CIDR blocks to create the subnet(s) for the desired Local Zone location(s).
+
+Refer to Step 2 in the previous section to extend your existing VPC creating nodes in Local Zones.
+
+Adjust the MTU of the cluster network in existing clusters according to your network plugin per RHOCP4: getting 'TLS handshake timeout' pulling images from AWS Local Zones workers.  
+
+Create the public subnet on Local Zone as described in Step 2 in the previous section.
+
+Next, enable the Zone group. Then, create the Local Zone subnet running the CloudFormation Template. Finally, create the Machine Set manifest, adapting to your existing cluster as per Step 4 in previous section.
+
+~~~bash
+cat <<EOF > | oc create -f -
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+(...)
+~~~
+
+## Deploy user-workloads in AWS Local Zones
+
+As described in “How to Create an OpenShift cluster with AWS Local Zones at install time” section above, there are a few use cases to run workloads in Local Zones. We demonstrate how to take advantage of Local Zones by deploying a sample application and selecting workers running in Local Zones.
+
+The compute nodes deployed in Local Zones have the following extra labels:
+
+~~~bash
+machine.openshift.com/zone-type: local-zone
+machine.openshift.com/zone-group: us-east-1-nyc-1
+node-role.kubernetes.io/edge: ""
+~~~
+
+You must set the proper tolerations to `node-role.kubernetes.io/edge`, selecting the node according to your use case.
+
+This example uses the `machine.openshift.com/zone-group` label to select the Local Zone node(s), creates the following deployment to create a sample application in the network border group of New York (us-east-1-nyc-1):
+
+~~~bash
+cat << EOF | oc create -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: lz-apps
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lz-app-nyc-1
+  namespace: lz-apps
+spec:
+  selector:
+    matchLabels:
+      app: lz-app-nyc-1
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: lz-app-nyc-1
+        zoneGroup: ${ZONE_GROUP_NAME}
+    spec:
+      nodeSelector:
+        machine.openshift.com/zone-group: ${ZONE_GROUP_NAME}
+      tolerations:
+      - key: "node-role.kubernetes.io/edge"
+        operator: "Equal"
+        value: ""
+        effect: "NoSchedule"
+      containers:
+        - image: openshift/origin-node
+          command:
+           - "/bin/socat"
+          args:
+            - TCP4-LISTEN:8080,reuseaddr,fork
+            - EXEC:'/bin/bash -c \"printf \\\"HTTP/1.0 200 OK\r\n\r\n\\\"; sed -e \\\"/^\r/q\\\"\"'
+          imagePullPolicy: Always
+          name: echoserver
+          ports:
+            - containerPort: 8080
+---
+apiVersion: v1
+kind: Service 
+metadata:
+  name:  lz-app-nyc-1 
+  namespace: lz-apps
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  type: NodePort
+  selector:
+    app: lz-app-nyc-1
+EOF
+~~~
+
+When we wrote this blog, Local Zones only supports AWS Application Load Balancer. To expose your application to end users, you create a custom ingress for each location by using the [AWS Application Load Balancer (ALB) Operator](https://docs.openshift.com/container-platform/4.12/networking/aws_load_balancer_operator/understanding-aws-load-balancer-operator.html).
+
+Create the ALB Operator following the steps listed in [Installing the AWS Load Balancer Operator](https://docs.openshift.com/container-platform/4.12/networking/aws_load_balancer_operator/install-aws-load-balancer-operator.html), then [Create the ALB Controller](https://docs.openshift.com/container-platform/4.12/networking/aws_load_balancer_operator/create-instance-aws-load-balancer-controller.html).
+
+Next, create the custom Ingress using Local Zone subnet.
+
+~~~bash
+cat << EOF | oc create -f -
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-lz-nyc-1
+  namespace: lz-apps
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: instance
+    alb.ingress.kubernetes.io/subnets: ${SUBNET_ID}
+  labels:
+    zoneGroup: ${ZONE_GROUP_NAME}
+spec:
+  ingressClassName: cloud
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: lz-app-nyc-1
+                port:
+                  number: 80
+EOF
+~~~
+
+Wait for the Load Balancer to get created.
+
+> TODO add images from AWS Console: Load Balancer, TG
+
+Once created, discover the ALB URL and test it.
+
+~~~bash
+$ HOST=$(oc get ingress -n lz-apps ingress-lz-nyc-1 --template='{{(index .status.loadBalancer.ingress 0).hostname}}')
+
+$ curl $HOST
+GET / HTTP/1.1
+X-Forwarded-For: 179.181.81.124
+X-Forwarded-Proto: http
+X-Forwarded-Port: 80
+Host: k8s-lzapps-ingressl-13226f2551-de.us-east-1.elb.amazonaws.com
+X-Amzn-Trace-Id: Root=1-63e18147-1532a244542b04bc75ffd473
+User-Agent: curl/7.61.1
+Accept: */*
+~~~
+
+To benchmark the performance, review the network time to connect between different locations:
+
+~~~bash
+# [1] NYC (outside AWS backbone)
+$ curl -s http://ip-api.com/json/$(curl -s ifconfig.me) |jq -r '[.city, .countryCode]'
+[  "North Bergen",   "US" ]
+$ curl -sw "%{time_namelookup}   %{time_connect}     %{time_starttransfer}    %{time_total}\n" -o /dev/null $HOST
+0.001452   0.004079     0.008914    0.009830
+
+# [2] Within the Region (master nodes)
+$ oc debug node/$(oc get nodes -l node-role.kubernetes.io/master -o jsonpath={'.items[0].metadata.name'}) -- chroot /host /bin/bash -c "\
+hostname; \
+curl -s http://ip-api.com/json/\$(curl -s ifconfig.me) |jq -r '[.city, .countryCode]';\
+curl -sw \"%{time_namelookup}   %{time_connect}     %{time_starttransfer}    %{time_total}\\n\" -o /dev/null $HOST"
+ip-10-0-54-118
+[ "Ashburn",  "US" ]
+0.002068   0.010196     0.019962    0.020985
+
+# [3] London (outside AWS backbone)
+$ curl -s http://ip-api.com/json/$(curl -s ifconfig.me) |jq -r '[.city, .countryCode]'
+[ "London", "GB" ]
+$ curl -sw "%{time_namelookup}   %{time_connect}     %{time_starttransfer}    %{time_total}\n" -o /dev/null $HOST
+0.003332   0.099921     0.197535    0.198802
+
+# [4] Brazil
+$ curl -s http://ip-api.com/json/$(curl -s ifconfig.me) |jq -r '[.city, .countryCode]'
+[ "Florianópolis", "BR" ]
+$ curl -sw "%{time_namelookup}   %{time_connect}     %{time_starttransfer}    %{time_total}\n" -o /dev/null $HOST
+0.022869   0.187408     0.355456    0.356435
+~~~
+
+The total time to connect, in seconds, from the client in NYC (outside AWS) to OpenShift edge node running in Local Zone was more than 2x faster compared with the client running in the regular zones.
+
+| Server / Client | [1]NYC/US | [2]AWS Region/use1 | [3]London/UK | [4]Brazil |
+| -- | -- | -- | -- | -- | -- |
+| us-east-1-nyc-1a | 0.004079 | 0.010196 | 0.099921 | 0.187408 |
+
+
+## Summary
+
+OpenShift provides a platform for easy deployment, scaling, and management of containerized applications across the hybrid cloud including AWS. Using OpenShift with AWS Local Zones provides numerous benefits for organizations. It allows for lower latency and improved network performance as Local Zones are physically closer to end users, which enhances the overall user experience and reduces downtime. The combination of OpenShift and AWS Local Zones provides a flexible and scalable solution that enables organizations to modernize their applications and meet the demands of their customers and users; 1) improving application performance and user experience, 2) hosting resources in specific geographic locations reducing overall cost and 3) providing regulated industries with a way to meet data residency requirements.
+

--- a/docs/blogs/ocp-aws-local-zones/ocp-aws-local-zones-414-demo.md
+++ b/docs/blogs/ocp-aws-local-zones/ocp-aws-local-zones-414-demo.md
@@ -1,0 +1,632 @@
+# Script for blog: Extending Red Hat OpenShift Container Platform to AWS Local Zones (4.14+)
+
+> This document will not be published, and can be skipped in the review process if you want. =]
+
+Hands-on script to deploy the entire environment described in the blog post.
+
+Just copy and paste it! =)
+
+> Note: keep attention in the details, outputs of commands. The steps are not fully safe checking/waiting resources to be created. You must double check it, some resources like EC2 could take longer preventing pods/workloads to be scheduled leading failures in variables discovery, like URL for the router while the service is not created.
+
+## Prerequisites
+
+- AWS CLI installed
+- AWS credentials exported with a user with permissions to create AWS cluster
+- Optionally, to measure the benchmark: Digital Ocean account and token created
+- Red Hat pull secret saved in the path `$PULL_SECRET_FILE`
+
+## Steps
+
+- Extract the openshift clients
+
+```bash
+# Extract OpenShift clients
+PULL_SECRET_FILE="$HOME/.openshift/pull-secret-latest.json"
+oc adm release extract --tools quay.io/openshift-release-dev/ocp-release:4.14.0-ec.4-x86_64 -a $PULL_SECRET_FILE
+tar xfz openshift-install-linux-4.14.0-ec.4.tar.gz
+tar xfz openshift-client-linux-4.14.0-ec.4.tar.gz
+```
+
+- Create the Cluster
+
+```bash
+# Extract cluster configuration
+export CLUSTER_NAME=demo-lz
+export CLUSTER_BASEDOMAIN="devcluster.openshift.com"
+export PULL_SECRET_PATH="$HOME/.openshift/pull-secret-latest.json"
+export SSH_KEYS="$(cat ~/.ssh/id_rsa.pub)"
+export AWS_REGION=us-east-1
+
+export LOCAL_ZONE_GROUP_NYC="${AWS_REGION}-nyc-1"
+export LOCAL_ZONE_NAME_NYC="${LOCAL_ZONE_GROUP_NYC}a"
+
+# enable zone group
+aws ec2 modify-availability-zone-group \
+    --group-name "${LOCAL_ZONE_GROUP_NYC}" \
+    --opt-in-status opted-in
+
+# Local Zone takes some time to be enabled (when not opted-in)
+sleep 60
+
+# Create install-config
+cat <<EOF > ${PWD}/install-config.yaml
+apiVersion: v1
+publish: External
+baseDomain: "${CLUSTER_BASEDOMAIN}"
+metadata:
+  name: "${CLUSTER_NAME}"
+compute:
+- name: edge
+  platform:
+    aws:
+      zones:
+      - ${LOCAL_ZONE_NAME_NYC}
+platform:
+  aws:
+    region: ${AWS_REGION}
+pullSecret: '$(cat ${PULL_SECRET_PATH} | awk -v ORS= -v OFS= '{$1=$1}1')'
+sshKey: |
+  ${SSH_KEYS}
+
+EOF
+
+./openshift-install create cluster --log-level=debug
+
+export KUBECONFIG=$PWD/auth/kubeconfig
+./oc get nodes -l node-role.kubernetes.io/edge
+./oc get machineset -n openshift-machine-api
+./oc get machine -n openshift-machine-api
+```
+
+- Extend the cluster
+
+
+```bash
+export LOCAL_ZONE_CIDR_BUE="10.0.208.0/24"
+export LOCAL_ZONE_GROUP_BUE="${AWS_REGION}-bue-1"
+export LOCAL_ZONE_NAME_BUE="${LOCAL_ZONE_GROUP_BUE}a"
+export SUBNET_NAME_BUE="${INFRA_ID}-public-${LOCAL_ZONE_NAME_BUE}"
+
+export PARENT_ZONE_NAME_BUE="$(aws ec2 describe-availability-zones \
+    --filters Name=zone-name,Values=${LOCAL_ZONE_NAME_BUE} \
+    --all-availability-zones \
+    --query AvailabilityZones[].ParentZoneName --output text)"
+
+aws ec2 describe-subnets \
+    --filters Name=vpc-id,Values=$VPC_ID \
+    --query 'sort_by(Subnets, &Tags[?Key==`Name`].Value|[0])[].{SubnetName: Tags[?Key==`Name`].Value|[0], CIDR: CidrBlock}'
+
+export INFRA_ID="$(./oc get infrastructure cluster -o jsonpath='{.status.infrastructureName}')"
+
+export VPC_ID=$(aws ec2 describe-vpcs --filters "Name=tag:Name,Values=${INFRA_ID}-vpc" --query Vpcs[].VpcId --output text)
+
+export VPC_RTB_PUB=$(aws ec2 describe-route-tables --filters "Name=tag:Name,Values=${INFRA_ID}-public" --query RouteTables[].RouteTableId --output text)
+
+# enable zone group
+aws ec2 modify-availability-zone-group \
+    --group-name "${LOCAL_ZONE_GROUP_BUE}" \
+    --opt-in-status opted-in
+
+# Local Zone takes some time to be enabled (when not opted-in)
+sleep 60
+
+export STACK_LZ=${INFRA_ID}-${LOCAL_ZONE_NAME_BUE}
+aws cloudformation create-stack --stack-name ${STACK_LZ} \
+  --template-body file://template-lz.yaml \
+  --parameters \
+      ParameterKey=VpcId,ParameterValue="${VPC_ID}" \
+      ParameterKey=PublicRouteTableId,ParameterValue="${VPC_RTB_PUB}" \
+      ParameterKey=ZoneName,ParameterValue="${LOCAL_ZONE_NAME_BUE}" \
+      ParameterKey=SubnetName,ParameterValue="${SUBNET_NAME_BUE}" \
+      ParameterKey=PublicSubnetCidr,ParameterValue="${LOCAL_ZONE_CIDR_BUE}" &&\
+  aws cloudformation wait stack-create-complete --stack-name ${STACK_LZ}
+
+aws cloudformation describe-stacks --stack-name ${STACK_LZ}
+
+export SUBNET_ID_BUE=$(aws cloudformation describe-stacks --stack-name "${STACK_LZ}" \
+  | jq -r .Stacks[0].Outputs[0].OutputValue)
+
+SG_NAME_INGRESS=${INFRA_ID}-localzone-ingress
+SG_ID_INGRESS=$(aws ec2 create-security-group \
+    --group-name ${SG_NAME_INGRESS} \
+    --description "${SG_NAME_INGRESS}" \
+    --vpc-id ${VPC_ID} | jq -r .GroupId)
+
+aws ec2 authorize-security-group-ingress \
+    --group-id $SG_ID_INGRESS \
+    --protocol tcp \
+    --port 80 \
+    --cidr "0.0.0.0/0"
+
+yq_version=v4.34.2
+yq_bin_arch=yq_linux_amd64
+wget https://github.com/mikefarah/yq/releases/download/${yq_version}/${yq_bin_arch} \
+  -O ./yq && chmod +x ./yq
+
+aws ec2 describe-instance-type-offerings --region ${AWS_REGION} \
+    --location-type availability-zone \
+    --filters Name=location,Values=${LOCAL_ZONE_NAME_BUE} \
+    --query 'InstanceTypeOfferings[*].InstanceType' --output text
+
+export INSTANCE_TYPE_BUE=m5.2xlarge
+
+lz_base=nyc
+lz_prefix=mia
+export BASE_MACHINESET_NYC=$(oc get machineset -n openshift-machine-api -o jsonpath='{range .items[*].metadata}{.name}{"\n"}{end}' | grep ${lz_base}-1)
+
+oc get machineset -n openshift-machine-api ${BASE_MACHINESET_NYC} -o yaml \
+  | sed -s "s/${lz_base}-1/${lz_prefix}-1/g" > machineset-lz-bue-1a.yaml
+
+KEYS=(.metadata.annotations)
+KEYS+=(.metadata.uid)
+KEYS+=(.metadata.creationTimestamp)
+KEYS+=(.metadata.resourceVersion)
+KEYS+=(.metadata.generation)
+KEYS+=(.spec.template.spec.providerSpec.value.subnet)
+KEYS+=(.spec.template.spec.providerSpec.value.securityGroups)
+KEYS+=(.status)
+for KEY in ${KEYS[*]}; do
+    ./yq -i "del($KEY)" machineset-lz-bue-1a.yaml
+done
+
+cat <<EOF > machineset-lz-bue-1a.patch.yaml
+spec:
+  replicas: 1
+  template:
+    spec:
+      metadata:
+        labels:
+          machine.openshift.io/parent-zone-name: ${PARENT_ZONE_NAME_BUE}
+      providerSpec:
+        value:
+          instanceType: ${INSTANCE_TYPE_BUE}
+          publicIP: yes
+          subnet:
+            filters:
+              - name: tag:Name
+                values:
+                  - ${SUBNET_NAME_BUE}
+          securityGroups:
+            - filters:
+              - name: "tag:Name"
+                values:
+                  - ${INFRA_ID}-worker-sg
+                  - ${SG_NAME_INGRESS}
+EOF
+
+./yq -i '. *= load("machineset-lz-bue-1a.patch.yaml")' machineset-lz-bue-1a.yaml
+
+./oc create -f machineset-lz-bue-1a.yaml
+
+./oc get machines -n openshift-machine-api -l machine.openshift.io/cluster-api-machine-role=edge 
+```
+
+- Create Deployment
+
+```bash
+export APPS_NAMESPACE="localzone-apps"
+./oc create namespace ${APPS_NAMESPACE}
+
+function create_deployment() {
+    local zone_group=$1; shift
+    local app_name=$1; shift
+    local set_toleration=${1:-''}
+    local tolerations=''
+    
+    if [[ $set_toleration == "yes" ]]; then
+        tolerations='
+      tolerations:
+      - key: "node-role.kubernetes.io/edge"
+        operator: "Equal"
+        value: ""
+        effect: "NoSchedule"'
+    fi
+    
+    cat << EOF | oc create -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${app_name}
+  namespace: ${APPS_NAMESPACE}
+spec:
+  selector:
+    matchLabels:
+      app: ${app_name}
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ${app_name}
+        zoneGroup: ${zone_group}
+    spec:
+      nodeSelector:
+        machine.openshift.io/zone-group: ${zone_group}
+${tolerations}
+      containers:
+        - image: openshift/origin-node
+          command:
+           - "/bin/socat"
+          args:
+            - TCP4-LISTEN:8080,reuseaddr,fork
+            - EXEC:'/bin/bash -c \"printf \\\"HTTP/1.0 200 OK\r\n\r\n\\\"; sed -e \\\"/^\r/q\\\"\"'
+          imagePullPolicy: Always
+          name: echoserver
+          ports:
+            - containerPort: 8080
+EOF
+}
+
+# App running in a node in New York
+create_deployment "${AWS_REGION}-nyc-1" "app-nyc-1" "yes"
+
+# App running in a node in Buenos Aires
+create_deployment "${AWS_REGION}-bue-1" "app-bue-1" "yes"
+
+NODE_NAME=$(./oc get nodes -l node-role.kubernetes.io/worker='',topology.kubernetes.io/zone=${AWS_REGION}a \
+  -o jsonpath='{.items[0].metadata.name}')
+
+./oc label node ${NODE_NAME} machine.openshift.io/zone-group=${AWS_REGION}
+
+# Deploy a running in a node in the regular zones
+create_deployment "${AWS_REGION}" "app-default"
+
+./oc get pods -o wide -n $APPS_NAMESPACE
+
+./oc get pods --show-labels -n $APPS_NAMESPACE
+```
+
+- Create ingress Default
+
+```bash
+cat << EOF | oc create -f -
+apiVersion: v1
+kind: Service 
+metadata:
+  name: app-default
+  namespace: ${APPS_NAMESPACE}
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  type: NodePort
+  selector:
+    app: app-default
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: app-default
+  namespace: ${APPS_NAMESPACE}
+spec:
+  port:
+    targetPort: 8080 
+  to:
+    kind: Service
+    name: app-default
+EOF
+
+APP_HOST_AZ="$(oc get -n ${APPS_NAMESPACE} route.route.openshift.io/app-default -o jsonpath='{.status.ingress[0].host}')"
+```
+
+### Install ALBO
+
+
+```bash
+# Create the Credentials for the Operator:
+ALBO_NS=aws-load-balancer-operator
+oc create namespace $ALBO_NS
+
+cat << EOF| oc create -f -
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: aws-load-balancer-operator
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries:
+      - action:
+          - ec2:DescribeSubnets
+        effect: Allow
+        resource: "*"
+      - action:
+          - ec2:CreateTags
+          - ec2:DeleteTags
+        effect: Allow
+        resource: arn:aws:ec2:*:*:subnet/*
+      - action:
+          - ec2:DescribeVpcs
+        effect: Allow
+        resource: "*"
+  secretRef:
+    name: aws-load-balancer-operator
+    namespace: aws-load-balancer-operator
+  serviceAccountNames:
+    - aws-load-balancer-operator-controller-manager
+EOF
+
+# Install the Operator from OLM:
+cat <<EOF | oc create -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: $ALBO_NS
+  namespace: $ALBO_NS
+spec:
+  targetNamespaces:
+  - $ALBO_NS
+EOF
+
+# Create the subscription:
+cat <<EOF | oc create -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: $ALBO_NS
+  namespace: $ALBO_NS
+spec:
+  channel: stable-v0
+  installPlanApproval: Automatic 
+  name: $ALBO_NS
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+oc get installplan -n $ALBO_NS
+oc get all -n $ALBO_NS
+```
+
+- Wait the resources to be created, then create the controller:
+
+```bash
+# Create cluster ALBO controller
+cat <<EOF | oc create -f -
+apiVersion: networking.olm.openshift.io/v1alpha1
+kind: AWSLoadBalancerController 
+metadata:
+  name: cluster 
+spec:
+  subnetTagging: Auto 
+  ingressClass: cloud 
+  config:
+    replicas: 2 
+  enabledAddons: 
+    - AWSWAFv2
+EOF
+
+# Wait for the pod becamig running
+oc get pods -w -n $ALBO_NS -l app.kubernetes.io/name=aws-load-balancer-operator
+```
+
+
+### Ingress for NYC (New York) Local Zone app
+
+- Deploy App in NYC using ALB as ingress
+
+```bash
+SUBNET_NAME_NYC="${INFRA_ID}-public-${LOCAL_ZONE_NAME_NYC}"
+
+SUBNET_ID_NYC=$(aws ec2 describe-subnets \
+  --filters Name=vpc-id,Values=$VPC_ID \
+  --query "Subnets[].{Name: Tags[?Key==\`Name\`].Value|[0], ID: SubnetId} | [?Name==\`${SUBNET_NAME_NYC}\`].ID" \
+  --output text)
+
+cat << EOF | oc create -f -
+apiVersion: v1
+kind: Service 
+metadata:
+  name: app-nyc-1
+  namespace: ${APPS_NAMESPACE}
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  type: NodePort
+  selector:
+    app: app-nyc-1
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-lz-nyc-1
+  namespace: ${APPS_NAMESPACE}
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: instance
+    alb.ingress.kubernetes.io/subnets: ${SUBNET_ID_NYC}
+  labels:
+    zoneGroup: us-east-1-nyc-1
+spec:
+  ingressClassName: cloud
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: app-nyc-1
+                port:
+                  number: 80
+EOF
+
+sleep 30
+
+APP_HOST_NYC=$(./oc get ingress -n ${APPS_NAMESPACE} ingress-lz-nyc-1 \
+  --template='{{(index .status.loadBalancer.ingress 0).hostname}}')
+
+while ! curl $APP_HOST_NYC; do sleep 5; done
+```
+
+### Ingress for BUE (Buenos Aires) Local Zone app
+
+
+```bash
+# Create a sharded ingressController
+cat << EOF | ./oc create -f -
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: ingress-lz-bue-1
+  namespace: openshift-ingress-operator
+  labels:
+    zoneGroup: ${LOCAL_ZONE_GROUP_BUE}
+spec:
+  endpointPublishingStrategy:
+    type: HostNetwork
+  replicas: 1
+  domain: apps-bue1.${CLUSTER_NAME}.${CLUSTER_BASEDOMAIN}
+  nodePlacement:
+    nodeSelector:
+      matchLabels:
+        machine.openshift.io/zone-group: ${LOCAL_ZONE_GROUP_BUE}
+    tolerations:
+      - key: "node-role.kubernetes.io/edge"
+        operator: "Equal"
+        value: ""
+        effect: "NoSchedule"
+  routeSelector:
+    matchLabels:
+      type: sharded
+EOF
+
+# Create the service and the route:
+cat << EOF | ./oc create -f -
+apiVersion: v1
+kind: Service 
+metadata:
+  name: app-bue-1
+  namespace: ${APPS_NAMESPACE}
+  labels:
+    zoneGroup: ${LOCAL_ZONE_GROUP_BUE}
+    app: app-bue-1
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  type: NodePort
+  selector:
+    app: app-bue-1
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: app-bue-1
+  namespace: ${APPS_NAMESPACE}
+  labels:
+    type: sharded
+spec:
+  host: app-bue-1.apps-bue1.${CLUSTER_NAME}.${CLUSTER_BASEDOMAIN}
+  port:
+    targetPort: 8080 
+  to:
+    kind: Service
+    name: app-bue-1
+EOF
+
+APP_HOST_BUE="$(./oc get route.route.openshift.io/app-$lz_prefix-1 \
+  -n ${APPS_NAMESPACE} -o jsonpath='{.status.ingress[0].host}')"
+
+IP_HOST_BUE="$(./oc get nodes -l topology.kubernetes.io/zone=us-east-1-$lz_prefix-1a -o json | jq -r '.items[].status.addresses[] | select (.type=="ExternalIP").address')"
+
+while ! curl -H "Host: $APP_HOST_BUE" http://$IP_HOST_BUE; do date; sleep 5; IP_HOST_BUE="$(./oc get nodes -l topology.kubernetes.io/zone=us-east-1-$lz_prefix-1a -o json | jq -r '.items[].status.addresses[] | select (.type=="ExternalIP").address')"; done
+
+```
+
+## Benchmark the applications
+
+- Generate the test script:
+
+```bash
+# Create the script
+cat <<EOF > curl.sh
+#!/usr/bin/env bash
+echo "# Client Location:"
+curl -s http://ip-api.com/json/\$(curl -s ifconfig.me) |jq -cr '[.city, .countryCode]'
+
+run_curl() {
+  echo -e "time_namelookup\t time_connect \t time_starttransfer \t time_total"
+  for idx in \$(seq 1 5); do
+    curl -sw "%{time_namelookup} \t %{time_connect} \t %{time_starttransfer} \t\t %{time_total}\n" \
+    -o /dev/null -H "Host: \$1" \${2:-\$1}
+  done
+}
+
+echo -e "\n# Collecting request times to server running in AZs/Regular zones \n# [endpoint ${APP_HOST_AZ}]"
+run_curl ${APP_HOST_AZ}
+
+echo -e "\n# Collecting request times to server running in Local Zone NYC \n# [endpoint ${APP_HOST_NYC}]"
+run_curl ${APP_HOST_NYC}
+
+echo -e "\n# Collecting request times to server running in Local Zone BUE \n# [endpoint ${APP_HOST_BUE}]"
+run_curl ${APP_HOST_BUE} ${IP_HOST_BUE}
+EOF
+
+```
+
+- Provision the external clients in NYC and UK using DigitalOcean Droplets, and test the endpoints:
+
+```bash
+
+# setup the external clients
+export DIGITALOCEAN_ACCESS_TOKEN=$MRBRAGA_DO_API_TOKEN
+doctl compute ssh-key create my-key --public-key "$(cat ~/.ssh/id_rsa.pub)"
+key_id=$(doctl compute ssh-key list | grep my-key | cut -f1 -d ' ')
+
+function create_droplet() {
+  region=$1; shift
+  name=$1;
+  doctl compute droplet create \
+  --image fedora-38-x64 \
+  --size s-1vcpu-1gb \
+  --region $region \
+  --ssh-keys ${key_id} \
+  --tag-name $name $name
+
+  echo "Waiting for droplet is active..."
+  while test "$(doctl compute droplet list --tag-name $name --no-header --format=Status)" != "active"; do sleep 5; done
+  doctl compute droplet list --tag-name $name
+
+  client_ip=$(doctl compute droplet list --tag-name $name -o json | jq -r '.[].networks.v4[] | select (.type=="public").ip_address')
+  export DROPLET_IP=$client_ip
+
+  echo "Waiting for SSH is UP in $client_ip..."
+  while ! ssh -o StrictHostKeyChecking=no root@$client_ip "echo ssh up"; do sleep 5; done
+  echo "Copying test script to remote host..."
+  scp -o StrictHostKeyChecking=no curl.sh root@$client_ip:~/
+}
+
+## Create NYC client
+export CLIENT_NAME_NYC=demo-localzones-test-nyc
+create_droplet nyc3 $CLIENT_NAME_NYC
+export CLIENT_IP_NYC=$DROPLET_IP
+
+## Create UK client
+export CLIENT_NAME_UK=demo-localzones-test-uk
+create_droplet lon1 $CLIENT_NAME_UK
+export CLIENT_IP_UK=$DROPLET_IP
+
+# Run tests locally and remote
+bash curl.sh
+ssh -o StrictHostKeyChecking=no root@$CLIENT_IP_NYC "bash curl.sh"
+ssh -o StrictHostKeyChecking=no root@$CLIENT_IP_UK "bash curl.sh"
+```
+
+- Destroy the clients:
+
+```bash
+# Destroy the droplets
+doctl compute droplet delete $CLIENT_NAME_NYC -f
+doctl compute droplet delete $CLIENT_NAME_UK -f
+```
+
+- Destroy cluster:
+
+```bash
+ ./openshift-install destroy cluster
+```

--- a/docs/blogs/ocp-aws-local-zones/ocp-aws-local-zones-414-full.md
+++ b/docs/blogs/ocp-aws-local-zones/ocp-aws-local-zones-414-full.md
@@ -1,0 +1,976 @@
+# Extending Red Hat OpenShift Container Platform to AWS Local Zones
+
+> Authors: Marco Braga, Marcos Entenza Garcia, Fatih Nar
+
+OpenShift users have many options when it comes to deploying a Red Hat OpenShift cluster
+in AWS. In Red Hat OpenShift Container Platform 4.12, we introduced the manual steps
+to extend cluster nodes into Amazon Web Services (AWS) Local Zones when installing in existing VPC.
+We are pleased to announce in OpenShift 4.14 the fully IPI (installer-provisioned infrastructure) automation
+to extend worker nodes to AWS Local Zones.
+
+## What is AWS Local Zones?
+
+[Local Zones][aws-localzones] allow you to use selected AWS services, like compute and storage services, closer to the metropolitan region, and end-users, than the regular zones, providing them with very low latency access to the applications running locally. Local Zones are fully owned and managed by AWS with no upfront commitment and no hardware purchase or lease required. In addition, Local Zones connect to the parent AWS cloud region via AWS' redundant and very high-bandwidth private network, providing applications running in Local Zones fast, secure, and seamless access to the rest of AWS services.
+
+![AWS Infrastructure Continuum][aws-infrastructure-continuum]
+
+<p align="center">Figure 1 AWS Infrastructure Continuum</p>
+
+## OpenShift and AWS Local Zones
+
+Using OpenShift with Local Zones, application developers and service consumers might have the following benefits:
+
+- Improving application performance and user experience by hosting resources closer to the user. Local Zones reduce the time it takes for data to travel over the network, resulting in faster load times and more responsive applications. This is especially important for applications, such as video streaming or online gaming, that require low-latency performance and real-time data access.
+- Saving costs by avoiding data transfer charges when hosting resources in specific geographic locations, whereby customers avoid high costs associated with data transfer charges, such as cloud egress charges, which is a significant business expense, when large volumes of data are moved between regions in the case of image, graphics, and video related applications.
+- Providing to regulated industries, such as healthcare, government agencies, financial institutions, and others, a way to meet data residency requirements by hosting data and applications in specific locations to comply with regulatory laws and mandates.
+
+## AWS Local Zones limitations in OpenShift
+
+There are a few limitations in the current AWS Local Zones offering that requires attention when deploying OpenShift:
+
+- The Maximum Transmission Unit (MTU) between an Amazon EC2 instance in a Local Zone and an Amazon EC2 instance in the Region is 1300. This causes the overlay network MTU to change according to the network plugin that is used on the deployment.
+- Network resources such as Network Load Balancer (NLB), Classic Load Balancer, and Nat Gateways are not globally available in AWS Local Zones, so the installer will not deploy those resources automatically.
+- The AWS Elastic Block Storage (EBS) volume type `gp3` is the default for node volumes and the storage class set on AWS OpenShift clusters. This volume type is not globally available in Local Zones locations. By default, the nodes running in Local Zones are deployed with the `gp2` EBS volume type, and the `gp2-csi` StorageClass must be set when creating workloads into those nodes.
+
+## Hands-on!
+
+The following sections describe how to deploy OpenShift compute nodes in Local Zones at cluster creation time, where the OpenShift Installer fully automates the cluster installation including network components in configured Local Zones. In addition, the Day 2 Operations section is added demonstrating how the cluster administrator extends compute nodes in Local Zones to an existing OpenShift cluster.
+
+After the cluster is installed, a sample application is deployed and exposed to ingress traffic throughout the zone, demonstrating workloads in Local Zones, and measuring the network connection time from different locations.
+
+The following diagram plots the geographically distributed deployment explored in this use case:
+
+> TODO> the following image will be replaced with less blank parts, focusing in the cluster and clients components
+
+![aws-local-zones-diagram-ocp-lz-413-map drawio][aws-local-zones-diagram-ocp-lz-413-map]
+
+<p align="center">Figure 2 User Workloads in Local Zones</p>
+
+The topology diagram below shows the infrastructure components created by the IPI installation:
+
+- One standard OpenShift Cluster is installed in `us-east-1` with three Control Plane nodes and three Compute nodes.
+- One regular VPC and subnets in Availability Zones.
+- Public and private subnets in the Local Zone of the New York metropolitan region (`us-east-1-nyc-1a`).
+- One `edge` compute node in the private subnet of `us-east-1-nyc-1a` zone;
+
+Additionally, the steps for the Day 2 operation create:
+
+- One Application Load Balancer exposing a sample application running in the Local Zone worker node.
+- One public subnet in the Buenos Aires metropolitan region (`us-east-1-bue-1a`).
+- One `edge` compute node in the public subnet of zone `us-east-1-bue-1a`
+
+![aws-local-zones-diagram-blog-hc-414-diagram drawio][aws-local-zones-diagram-blog-hc-414-diagram]
+
+<p align="center">Figure 3 OpenShift Cluster installed in us-east-1 extending nodes to Local Zone in New York</p>
+
+## Installing an OpenShift cluster with AWS Local Zones
+
+To deploy an OpenShift cluster extending compute nodes in Local Zone subnets, it is required to define the `edge` compute pool in the `install-config.yaml` file, not enabled by default.
+
+The installation process creates the network components in Local Zone classifying those as "Edge Zone", creating MachineSet manifests for each location. See the [OpenShift documentation][ocp-docs-localzone] for more details.
+
+Once the cluster is installed, the label `node-role.kubernetes.io/edge` is set to each node located in the Local Zones, along with the regular `node-role.kubernetes.io/worker`.
+
+### Prerequisites
+
+Install the following prerequisites before you proceed to the next step:
+
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+- [OpenShift Installer 4.14+](https://console.redhat.com/openshift/downloads)
+- [OpenShift CLI](https://console.redhat.com/openshift/downloads)
+
+### Step 1. Enable the AWS Local Zone Group
+
+The zones in Local Zones are not enabled by default, the zone group needs to opt-in before creating resources in those locations.
+
+You can list the available Local Zones and the attributes using the operation DescribeAvailabilityZones with AWS CLI:
+
+```bash
+aws --region us-east-1 ec2 describe-availability-zones \
+    --query 'AvailabilityZones[].[{ZoneName: ZoneName, GroupName: GroupName, Status: OptInStatus}]' \
+    --filters Name=zone-type,Values=local-zone \
+    --all-availability-zones
+```
+
+To enable the Local Zone in New York (used in this post), run:
+
+```bash
+aws ec2 modify-availability-zone-group \
+    --group-name "us-east-1-nyc-1" \
+    --opt-in-status opted-in
+```
+
+### Step 2. Create the OpenShift Cluster
+
+Create the `install-config.yaml` setting for the AWS Local Zone name in the `edge`
+compute pool:
+
+~~~yaml
+apiVersion: v1
+publish: External
+baseDomain: "<CHANGE_ME: Base Domain>"
+metadata:
+  name: demo-lz
+compute:
+  - name: edge
+    platform:
+      aws:
+        zones:
+        - us-east-1-nyc-1a
+platform:
+  aws:
+    region: us-east-1
+pullSecret: '<CHANGE_ME: pull-secret-content>'
+sshKey: |
+  '<CHANGE_ME: ssh-keys>'
+~~~
+
+Create the cluster:
+
+~~~bash
+./openshift-install create cluster
+~~~
+
+That's it, the installer program creates all the infrastructure and configuration required to extend worker nodes in the selected location.
+
+Once the installation is finished, review the EC2 worker node status provisioned by Machine API:
+
+~~~bash
+export KUBECONFIG=$PWD/auth/kubeconfig
+./oc get machines -l machine.openshift.io/cluster-api-machine-role=edge -n openshift-machine-api
+~~~
+~~~text
+NAME                                        PHASE     TYPE          REGION      ZONE               AGE
+demo-lz-tvqld-edge-us-east-1-nyc-1a-scgjl   Running   c5d.2xlarge   us-east-1   us-east-1-nyc-1a   21m
+~~~
+
+You can also check the nodes created in AWS Local Zones after the machine is in the `Running` phase, labeled with `node-role.kubernetes.io/edge`:
+
+~~~bash
+./oc get nodes -l node-role.kubernetes.io/edge
+~~~
+~~~text
+NAME                           STATUS   ROLES         AGE     VERSION
+ip-10-0-194-188.ec2.internal   Ready    edge,worker   5m45s   v1.27.3+4aaeaec
+~~~
+
+![ocp-aws-localzones-step4-ocp-nodes-ec2][ocp-aws-localzones-step4-ocp-nodes-ec2]
+
+<p align="center">Figure 4: OpenShift nodes created by the installer in AWS EC2 Console</p>
+
+## Extending an existing OpenShift cluster to new AWS Local Zones
+
+It is also possible to extend the existing cluster installed with the support of
+Local Zones (Day 2) to new locations, allowing you to expand geographically
+when it needs.
+
+The steps in this section describe the Day 2 operations steps to extend
+the compute node to a new location of Buenos Aires (`us-east-1-bue-1a`) in an existing
+OpenShift cluster
+
+### Prerequisites
+
+- The cluster must be installed with Local Zones support. If the cluster was not installed using IPI with Local Zone support, the Maximum Transmit Unit (MTU) for the cluster-wide network must be adjusted before proceeding. See the "[AWS Local Zone tasks][ocp-aws-localzones-day2]" in the OpenShift documentation for more information.
+
+- Export the variables:
+
+```bash
+export CLUSTER_NAME=demo-lz
+export CLUSTER_BASEDOMAIN="example.com"
+
+export AWS_REGION=us-east-1
+export LOCAL_ZONE_GROUP_NYC="${AWS_REGION}-nyc-1"
+export LOCAL_ZONE_NAME_NYC="${LOCAL_ZONE_GROUP_NYC}a"
+
+export INFRA_ID="$(./oc get infrastructure cluster -o jsonpath='{.status.infrastructureName}')"
+
+export VPC_ID=$(aws ec2 describe-vpcs --filters "Name=tag:Name,Values=${INFRA_ID}-vpc" --query Vpcs[].VpcId --output text)
+```
+
+- The VPC running the cluster must have available CIDR blocks to create the subnet(s). You can check existing CIDR blocks allocated to the subnets within the VPC by running the following command:
+
+```bash
+aws ec2 describe-subnets \
+  --filters Name=vpc-id,Values=$VPC_ID \
+  --query 'sort_by(Subnets, &Tags[?Key==`Name`].Value|[0])[].{
+    SubnetName: Tags[?Key==`Name`].Value|[0],
+    CIDR: CidrBlock
+  }'
+```
+
+- Install `yq` utility to help when patching the manifests
+
+```bash
+yq_version=v4.34.2
+yq_bin_arch=yq_linux_amd64
+wget https://github.com/mikefarah/yq/releases/download/${yq_version}/${yq_bin_arch} \
+  -O ./yq && chmod +x ./yq
+```
+
+### Step 1. Create the public subnet in the AWS Local Zone
+
+The step describes how to create a subnet associated with the VPC Public Route table created by the installer using the AWS Cloud Formation template provided by OpenShift Installer.
+
+- Create the required environment variables to create the subnet in the zone `us-east-1-bue-1a`:
+
+~~~bash
+export LOCAL_ZONE_CIDR_BUE="10.0.208.0/24"
+export LOCAL_ZONE_GROUP_BUE="${AWS_REGION}-bue-1"
+export LOCAL_ZONE_NAME_BUE="${LOCAL_ZONE_GROUP_BUE}a"
+export PARENT_ZONE_NAME_BUE="$(aws ec2 describe-availability-zones \
+  --all-availability-zones \
+  --filters Name=zone-name,Values=${LOCAL_ZONE_NAME_BUE} \
+  --query AvailabilityZones[].ParentZoneName --output text)"
+
+export VPC_RTB_PUB=$(aws ec2 describe-route-tables \
+  --filters "Name=tag:Name,Values=${INFRA_ID}-public" \
+  --query RouteTables[].RouteTableId --output text)
+
+export SUBNET_NAME_BUE="${INFRA_ID}-public-${LOCAL_ZONE_NAME_BUE}"
+export STACK_LZ=${INFRA_ID}-${LOCAL_ZONE_NAME_BUE}
+~~~
+
+- Enable the Zone Group:
+
+```bash
+aws ec2 modify-availability-zone-group \
+    --group-name "${LOCAL_ZONE_GROUP_BUE}" \
+    --opt-in-status opted-in
+```
+
+- Download the CloudFormation Template from the OpenShift documentation saving with the name `template-lz.yaml`: [CloudFormation template for the subnet that uses AWS Local Zones][ocp-aws-cloudformation-localzone-subnet].
+
+- Create the CloudFormation stack to deploy the Local Zone subnet:
+
+```bash
+aws cloudformation create-stack --stack-name ${STACK_LZ} \
+  --template-body file://template-lz.yaml \
+  --parameters \
+      ParameterKey=VpcId,ParameterValue="${VPC_ID}" \
+      ParameterKey=PublicRouteTableId,ParameterValue="${VPC_RTB_PUB}" \
+      ParameterKey=ZoneName,ParameterValue="${LOCAL_ZONE_NAME_BUE}" \
+      ParameterKey=SubnetName,ParameterValue="${SUBNET_NAME_BUE}" \
+      ParameterKey=PublicSubnetCidr,ParameterValue="${LOCAL_ZONE_CIDR_BUE}" &&\
+  aws cloudformation wait stack-create-complete --stack-name ${STACK_LZ}
+```
+
+- Export the subnet ID to be used later when creating a custom Ingress Controller:
+
+```bash
+export SUBNET_ID_BUE=$(aws cloudformation describe-stacks --stack-name "${STACK_LZ}" \
+  | jq -r .Stacks[0].Outputs[0].OutputValue)
+```
+
+![ocp-aws-localzones-step5-cfn-subnet-bue-1a][ocp-aws-localzones-step5-cfn-subnet-bue-1a]
+
+<p align="center">Figure 5: CloudFormation Stack for Local Zone subnet in us-east-1-bue-1a</p>
+
+### Step 2. Create the additional Security Group
+
+An additional security group with rules allowing ingress traffic for the ingress will be created and attached to the nodes in `us-east-1-bue-1a` zone. It is created to handle the existing Application Load Balancer (ALB) limitation in some locations, preventing the ingress traffic from a regular cloud-based load balancer through the ingress controller.
+
+```bash
+SG_NAME_INGRESS=${INFRA_ID}-localzone-ingress
+SG_ID_INGRESS=$(aws ec2 create-security-group \
+  --group-name ${SG_NAME_INGRESS} \
+  --description "${SG_NAME_INGRESS}" \
+  --vpc-id ${VPC_ID} | jq -r .GroupId)
+```
+
+Create the Security Group inbound rule allowing traffic by HTTP(80) used by the sharded ingress controller:
+
+```bash
+aws ec2 authorize-security-group-ingress \
+  --group-id $SG_ID_INGRESS \
+  --protocol tcp \
+  --port 80 \
+  --cidr "0.0.0.0/0"
+```
+
+### Step 3. Create MachineSet
+
+The OpenShift component responsible for creating instances in the cloud provider is the Machine API (MAPI). The MachineSet manifest is added setting the zone attributes, and edge compute pool labels created by the installer.
+
+The steps below show how to check the instance offered by the zone, and create the MachineSet manifest based on the existing one created by the installer (`us-east-1-nyc-1a`) to the Local Zone in Buenos Aires(`us-east-1-bue-1a`):
+
+<!-- > Note: The Local Zone of Buenos Aires (`us-east-1-bue-1a`) was intentionally picked as it currently does not support AWS Application Load Balancers (ALB), used in New York zone (`us-east-1-nyc-1a`). -->
+
+- Check and export the instance type offered by the Zone:
+
+```bash
+aws ec2 describe-instance-type-offerings --region ${AWS_REGION} \
+  --location-type availability-zone \
+  --filters Name=location,Values=${LOCAL_ZONE_NAME_BUE} \
+  --query 'InstanceTypeOfferings[*].InstanceType' --output text
+```
+```text
+t3.xlarge   c5.4xlarge
+t3.medium   c5.12xlarge
+c5.2xlarge  r5.2xlarge  m5.2xlarge
+g4dn.2xlarge
+```
+
+- Set the name of the desired type:
+
+```bash
+export INSTANCE_TYPE_BUE=m5.2xlarge
+```
+
+- Export existing Machineset manifest and patch to the new location:
+
+```bash
+# Discover the machineset name from nyc-1
+export BASE_MACHINESET_NYC=$(./oc get machineset -n openshift-machine-api \
+  -o jsonpath='{range .items[*].metadata}{.name}{"\n"}{end}' | grep nyc-1)
+
+# Extract the machineset manifest from nyc replacing the zone reference from NYC to BUE
+./oc get machineset -n openshift-machine-api ${BASE_MACHINESET_NYC} -o yaml \
+  | sed -s "s/nyc-1/bue-1/g" > machineset-lz-bue-1a.yaml
+
+# Remove unused configurations
+KEYS=(.metadata.annotations)
+KEYS+=(.metadata.uid)
+KEYS+=(.metadata.creationTimestamp)
+KEYS+=(.metadata.resourceVersion)
+KEYS+=(.metadata.generation)
+KEYS+=(.spec.template.spec.providerSpec.value.subnet)
+KEYS+=(.spec.template.spec.providerSpec.value.securityGroups)
+KEYS+=(.status)
+for KEY in ${KEYS[*]}; do
+    ./yq -i "del($KEY)" machineset-lz-bue-1a.yaml
+done
+
+# Create a patch for the new location
+cat <<EOF > machineset-lz-bue-1a.patch.yaml
+spec:
+  replicas: 1
+  template:
+    spec:
+      metadata:
+        labels:
+          machine.openshift.io/parent-zone-name: ${PARENT_ZONE_NAME_BUE}
+      providerSpec:
+        value:
+          instanceType: ${INSTANCE_TYPE_BUE}
+          publicIP: yes
+          subnet:
+            filters:
+              - name: tag:Name
+                values:
+                  - ${SUBNET_NAME_BUE}
+          securityGroups:
+            - filters:
+              - name: "tag:Name"
+                values:
+                  - ${INFRA_ID}-worker-sg
+                  - ${INFRA_ID}-localzone-public-ingress
+EOF
+
+# Apply the patch
+./yq -i '. *= load("machineset-lz-bue-1a.patch.yaml")' machineset-lz-bue-1a.yaml
+```
+
+- Create the Machineset:
+
+```bash
+./oc create -f machineset-lz-bue-1a.yaml
+```
+
+- Wait for the machine creation:
+
+```bash
+./oc get machines -n openshift-machine-api -l machine.openshift.io/cluster-api-machine-role=edge
+```
+```text
+NAME                                        PHASE         TYPE          REGION      ZONE               AGE
+demo-lz-tvqld-edge-us-east-1-bue-1a-rvbb5   Provisioned   m5.2xlarge    us-east-1   us-east-1-bue-1a   79s
+demo-lz-tvqld-edge-us-east-1-nyc-1a-scgjl   Running       c5d.2xlarge   us-east-1   us-east-1-nyc-1a   4h43m
+```
+
+The instance creation could take some time to finish, make sure the machine is in the Running phase before proceeding to the next steps.
+
+All done, now the cluster has nodes running into two Local Zones: New York (US) and Buenos Aires (Argentina).
+
+![ocp-aws-localzones-step5-ec2-bue-1a][ocp-aws-localzones-step5-ec2-bue-1a]
+
+<p align="center">Figure 6: OpenShift nodes running in AWS Local Zones in EC2 Console</p>
+
+## Deploying workloads in AWS Local Zones
+
+This section demonstrates how to take advantage of Local Zones by deploying a sample application and selecting workers running into different locations.
+
+Three deployments are created:
+
+- Application running in the Region: ingressing the traffic using the OpenShift default router
+- Application running in Local Zone NYC (US): ingressing traffic using Application Load Balancer
+- Application running in Local Zone Buenos Aires (Argentina): ingressing traffic directly to the node (currently the zone does not support AWS Application Load Balancers)
+
+The `edge` compute nodes deployed in Local Zones have the following extra labels:
+
+~~~yaml
+machine.openshift.io/zone-type: local-zone
+machine.openshift.io/zone-group: us-east-1-<localzone_identifier>-1
+node-role.kubernetes.io/edge: ""
+~~~
+
+You must set the tolerations to `node-role.kubernetes.io/edge`, selecting the node according to your use case.
+
+The example below uses the `machine.openshift.io/zone-group` label to select the node(s), and creates the deployment for a sample application in the respective zone's network border group:
+
+- Create the namespace:
+
+~~~bash
+export APPS_NAMESPACE="localzone-apps"
+./oc create namespace ${APPS_NAMESPACE}
+~~~
+
+- Create the function to create the deployments for each location:
+
+~~~bash
+function create_deployment() {
+    local zone_group=$1; shift
+    local app_name=$1; shift
+    local set_toleration=${1:-''}
+    local tolerations=''
+    
+    if [[ $set_toleration == "yes" ]]; then
+        tolerations='
+      tolerations:
+      - key: "node-role.kubernetes.io/edge"
+        operator: "Equal"
+        value: ""
+        effect: "NoSchedule"'
+    fi
+    
+    cat << EOF | oc create -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${app_name}
+  namespace: ${APPS_NAMESPACE}
+spec:
+  selector:
+    matchLabels:
+      app: ${app_name}
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ${app_name}
+        zoneGroup: ${zone_group}
+    spec:
+      nodeSelector:
+        machine.openshift.io/zone-group: ${zone_group}
+${tolerations}
+      containers:
+        - image: openshift/origin-node
+          command:
+           - "/bin/socat"
+          args:
+            - TCP4-LISTEN:8080,reuseaddr,fork
+            - EXEC:'/bin/bash -c \"printf \\\"HTTP/1.0 200 OK\r\n\r\n\\\"; sed -e \\\"/^\r/q\\\"\"'
+          imagePullPolicy: Always
+          name: echoserver
+          ports:
+            - containerPort: 8080
+EOF
+}
+~~~
+
+- Create the application for each location:
+
+~~~bash
+# App running in a node in New York
+create_deployment "${AWS_REGION}-nyc-1" "app-nyc-1" "yes"
+
+# App running in a node in Buenos Aires
+create_deployment "${AWS_REGION}-bue-1" "app-bue-1" "yes"
+~~~
+
+Lastly, to deploy the application in the nodes running in the Region (regular/Availability Zones), a random node is picked and set up:
+
+~~~bash
+NODE_NAME=$(./oc get nodes -l node-role.kubernetes.io/worker='',topology.kubernetes.io/zone=${AWS_REGION}a \
+  -o jsonpath='{.items[0].metadata.name}')
+
+./oc label node ${NODE_NAME} machine.openshift.io/zone-group=${AWS_REGION}
+
+# Deploy a running in a node in the regular zones
+create_deployment "${AWS_REGION}" "app-default"
+~~~
+
+All set, all applications must be running into different locations:
+
+```bash
+./oc get pods -o wide  -n $APPS_NAMESPACE
+```
+```text
+NAME                           READY   STATUS    RESTARTS   AGE     IP            NODE                          NOMINATED NODE   READINESS GATES
+app-bue-1-689b95f4c4-jf6fb     1/1     Running   0          5m4s    10.131.2.6    ip-10-0-156-17.ec2.internal   <none>           <none>
+app-default-857b5dc59f-r8cst   1/1     Running   0          75s     10.130.2.24   ip-10-0-51-38.ec2.internal    <none>           <none>
+app-nyc-1-54ffd5c89b-bbhqp     1/1     Running   0          5m31s   10.131.0.6    ip-10-0-128-81.ec2.internal   <none>           <none>
+```
+```bash
+./oc get pods --show-labels -n $APPS_NAMESPACE
+```
+```text
+NAME                           READY   STATUS    RESTARTS   AGE     LABELS
+app-bue-1-689b95f4c4-jf6fb     1/1     Running   0          5m16s   app=app-bue-1,pod-template-hash=689b95f4c4,zoneGroup=us-east-1-bue-1
+app-default-857b5dc59f-r8cst   1/1     Running   0          87s     app=app-default,pod-template-hash=857b5dc59f,zoneGroup=us-east-1
+app-nyc-1-54ffd5c89b-bbhqp     1/1     Running   0          5m43s   app=app-nyc-1,pod-template-hash=54ffd5c89b,zoneGroup=us-east-1-nyc-1
+```
+
+## Exposing applications to ingress traffic from internet
+
+It's time to create to expose the application to the internet targeting ingressing the traffic from each zone group.
+
+When this blog was written, Local Zones had limited support of AWS Load Balancers, supporting only AWS Application Load Balancer (ALB) with limited locations. To expose the application to end users using ALB, you need to create, when supported, a custom ingress for each location by using the [AWS Application Load Balancer (ALB) Operator][ocp-aws-albo].
+
+In our example, only NYC Zone supports ALB and will use it to expose the sample app.  A new sharded router is deployed running in `Buenos Aires` node, ingressing the traffic directly from that location (`us-east-1-bue-1a`).
+
+> Q: Do we need to add a diagram showing those three different types of exposing applications?
+
+### Ingress for Availability Zone's app
+
+Create the service and expose the application running in the region using the default router:
+
+~~~bash
+cat << EOF | oc create -f -
+apiVersion: v1
+kind: Service 
+metadata:
+  name: app-default
+  namespace: ${APPS_NAMESPACE}
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  type: NodePort
+  selector:
+    app: app-default
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: app-default
+  namespace: ${APPS_NAMESPACE}
+spec:
+  port:
+    targetPort: 8080 
+  to:
+    kind: Service
+    name: app-default
+EOF
+~~~
+
+- After the Load Balancer is created, export the `APP_HOST_AZ` address for that location:
+
+```bash
+APP_HOST_AZ="$(oc get -n ${APPS_NAMESPACE} route.route.openshift.io/app-default -o jsonpath='{.status.ingress[0].host}')"
+```
+
+### Ingress for NYC (New York) Local Zone app
+
+Create the ALB Operator following the steps listed in [Installing the AWS Load Balancer Operator][ocp-aws-albo-installing], then [Create the ALB Controller][ocp-aws-albo-controller].
+
+- Make sure the ALB Controllers are running before proceeding:
+
+```bash
+./oc get pods -n aws-load-balancer-operator 
+```
+```text
+NAME                                                             READY   STATUS    RESTARTS   AGE
+aws-load-balancer-controller-cluster-567bc99b68-rnkjn            1/1     Running   0          43s
+aws-load-balancer-controller-cluster-567bc99b68-s7w4z            1/1     Running   0          43s
+aws-load-balancer-operator-controller-manager-7674db45d6-hmswz   2/2     Running   0          90s
+```
+
+- Extract the public subnet ID from NYC's Local Zone used by the Application load Balancer:
+
+```bash
+SUBNET_NAME_NYC="${INFRA_ID}-public-${LOCAL_ZONE_NAME_NYC}"
+
+SUBNET_ID_NYC=$(aws ec2 describe-subnets \
+  --filters Name=vpc-id,Values=$VPC_ID \
+  --query "Subnets[].{Name: Tags[?Key==\`Name\`].Value|[0], ID: SubnetId} | [?Name==\`${SUBNET_NAME_NYC}\`].ID" \
+  --output text)
+```
+
+- Create the custom Ingress on that location:
+
+```bash
+cat << EOF | oc create -f -
+apiVersion: v1
+kind: Service 
+metadata:
+  name: app-nyc-1
+  namespace: ${APPS_NAMESPACE}
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  type: NodePort
+  selector:
+    app: app-nyc-1
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-lz-nyc-1
+  namespace: ${APPS_NAMESPACE}
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: instance
+    alb.ingress.kubernetes.io/subnets: ${SUBNET_ID_NYC}
+  labels:
+    zoneGroup: us-east-1-nyc-1
+spec:
+  ingressClassName: cloud
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: app-nyc-1
+                port:
+                  number: 80
+EOF
+```
+
+- Review the new ingress:
+
+```bash
+./oc get ingress  -n ${APPS_NAMESPACE}
+```
+```text
+NAME               CLASS   HOSTS   ADDRESS                                                                   PORTS   AGE
+ingress-lz-nyc-1   cloud   *       k8s-localzon-ingressl-814f3fc007-1883787437.us-east-1.elb.amazonaws.com   80      4s
+```
+
+![ocp-aws-localzones-step7-alb-nyc][ocp-aws-localzones-step7-alb-nyc]
+
+<p align="center">Figure 7: Load Balancer created for the ingress using NYC Local Zone subnet</p>
+
+![ocp-aws-localzones-step7-alb-tg-nyc][ocp-aws-localzones-step7-alb-tg-nyc]
+
+<p align="center">Figure 8: Target Group added the Local Zone node as a target</p>
+
+Once the Application Load Balancer has been provisioned, get the DNS name and test it:
+
+```bash
+APP_HOST_NYC=$(./oc get ingress -n ${APPS_NAMESPACE} ingress-lz-nyc-1 \
+  --template='{{(index .status.loadBalancer.ingress 0).hostname}}')
+
+while ! curl $APP_HOST_NYC; do sleep 5; done
+```
+```text
+GET / HTTP/1.1
+(...)
+```
+
+### Ingress for BUE (Buenos Aires) Local Zone app
+
+Create a sharded ingress controller running in the `Buenos Aires` node using HostNetwork:
+
+~~~bash
+$ cat << EOF | ./oc create -f -
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: ingress-lz-bue-1
+  namespace: openshift-ingress-operator
+  labels:
+    zoneGroup: us-east-1
+spec:
+  endpointPublishingStrategy:
+    type: HostNetwork
+  replicas: 1
+  domain: apps-bue1.${CLUSTER_NAME}.${CLUSTER_BASEDOMAIN}
+  nodePlacement:
+    nodeSelector:
+      matchLabels:
+        machine.openshift.io/zone-group: us-east-1-bue-1
+    tolerations:
+      - key: "node-role.kubernetes.io/edge"
+        operator: "Equal"
+        value: ""
+        effect: "NoSchedule"
+  routeSelector:
+    matchLabels:
+      type: sharded
+EOF
+~~~
+
+Create the service and the route:
+
+~~~bash
+$ cat << EOF | ./oc create -f -
+apiVersion: v1
+kind: Service 
+metadata:
+  name: app-bue-1
+  namespace: ${APPS_NAMESPACE}
+  labels:
+    zoneGroup: us-east-1-bue-1
+    app: app-bue-1
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  type: NodePort
+  selector:
+    app: app-bue-1
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: app-bue-1
+  namespace: ${APPS_NAMESPACE}
+  labels:
+    type: sharded
+spec:
+  host: app-bue-1.apps-bue1.${CLUSTER_NAME}.${CLUSTER_BASEDOMAIN}
+  port:
+    targetPort: 8080 
+  to:
+    kind: Service
+    name: app-bue-1
+EOF
+~~~
+
+Discover and set the Buenos Aires' ingress address:
+
+```bash
+APP_HOST_BUE="$(./oc get route.route.openshift.io/app-bue-1 -o jsonpath='{.status.ingress[0].host}')"
+
+IP_HOST_BUE="$(./oc get nodes -l topology.kubernetes.io/zone=us-east-1-bue-1a -o json | jq -r '.items[].status.addresses[] | select (.type=="ExternalIP").address')"
+
+curl -H "Host: $APP_HOST_BUE" http://$IP_HOST_BUE
+```
+
+<!-- 
+> TMP Note: DNS config: the controller is not adding the DNSes to the public zone for the custom ingress controller. How DNS creates RR automatically for the sharded routers which don't use service LB, but HostNetwork with public IP address on the host interface? -->
+
+## Benchmarking the applications connection time
+
+It is time to test each application endpoint from different locations on the internet, some are closer to the metropolitan regions located in the Local Zone, so we'll be able to measure the network benefits of using edge compute pools in OpenShift.
+
+The tests make a few requests from different clients, extracting the [`curl` variables writing it out][curl-vars-wout] to the console.
+
+Generate the script `curl.sh` to test the endpoints:
+
+~~~bash
+cat <<EOF > curl.sh
+#!/usr/bin/env bash
+echo "# Client Location:"
+curl -s http://ip-api.com/json/\$(curl -s ifconfig.me) |jq -r '[.city, .countryCode]'
+
+run_curl() {
+  echo -e "time_namelookup\t time_connect \t time_starttransfer \t time_total"
+  for idx in \$(seq 1 5); do
+    curl -sw "%{time_namelookup} \t %{time_connect} \t %{time_starttransfer} \t\t %{time_total}\n" \
+    -o /dev/null -H "Host: \$1" \${2:-\$1}
+  done
+}
+
+echo -e "\n# Collecting request times to server running in AZs/Regular zones \n# [endpoint ${APP_HOST_AZ}]"
+run_curl ${APP_HOST_AZ}
+
+echo -e "\n# Collecting request times to server running in Local Zone NYC \n# [endpoint ${APP_HOST_NYC}]"
+run_curl ${APP_HOST_NYC}
+
+echo -e "\n# Collecting request times to server running in Local Zone BUE \n# [endpoint ${APP_HOST_BUE}]"
+run_curl ${APP_HOST_BUE} ${IP_HOST_BUE}
+EOF
+~~~
+
+Copy and run `curl.sh` to the clients and run it:
+
+```bash
+bash curl.sh 
+```
+
+- Results of the **client** located in the region of **US/New York**:
+
+```text
+# Client Location: 
+["North Bergen", "US"]
+
+# Collecting request times to server running in AZs/Regular zones
+# [endpoint app-default-localzone-apps.apps.demo-lz.devcluster.openshift.com]
+time_namelookup  time_connect    time_starttransfer      time_total
+0.010444         0.018078        0.031563                0.032449
+0.012000         0.019141        0.030801                0.031725
+0.000777         0.007918        0.019087                0.019860
+0.001437         0.008690        0.020179                0.020955
+0.005015         0.011915        0.023527                0.024309
+
+# Collecting request times to server running in Local Zone NYC
+# [endpoint k8s-localzon-ingressl-573f917a81-716983909.us-east-1.elb.amazonaws.com]
+time_namelookup  time_connect    time_starttransfer      time_total
+0.002986         0.005248        0.009702                0.010571
+0.001368         0.003183        0.006447                0.007270
+0.001100         0.002503        0.005711                0.006586
+0.003174         0.004643        0.007955                0.008725
+0.003144         0.004601        0.007663                0.008500
+
+# Collecting request times to server running in Local Zone BUE
+# [endpoint app-bue-1.apps-bue1.demo-lz.devcluster.openshift.com]
+time_namelookup  time_connect    time_starttransfer      time_total
+0.000026         0.141142        0.284566                0.285606
+0.000027         0.141474        0.284454                0.285362
+0.000025         0.141334        0.284213                0.285045
+0.000023         0.141085        0.283620                0.284515
+0.000026         0.141586        0.284625                0.285490
+```
+
+- Results of the **client** located in the region of **UK/London**:
+
+~~~text
+# Client Location: 
+["Enfield", "GB"]
+
+# Collecting request times to server running in AZs/Regular zones
+# [endpoint app-default-localzone-apps.apps.demo-lz.devcluster.openshift.com]
+time_namelookup  time_connect    time_starttransfer      time_total
+0.014856         0.096285        0.181679                0.182629
+0.001565         0.079669        0.162386                0.163355
+0.001891         0.081879        0.165896                0.166834
+0.001465         0.080108        0.163756                0.164491
+0.001224         0.081282        0.165828                0.166998
+
+# Collecting request times to server running in Local Zone NYC
+# [endpoint k8s-localzon-ingressl-573f917a81-716983909.us-east-1.elb.amazonaws.com]
+time_namelookup  time_connect    time_starttransfer      time_total
+0.002339         0.092894        0.184171                0.185058
+0.001506         0.085278        0.167627                0.168613
+0.001176         0.083452        0.167570                0.168474
+0.001483         0.092990        0.186173                0.186859
+0.001130         0.083462        0.167462                0.168527
+
+# Collecting request times to server running in Local Zone BUE
+# [endpoint app-bue-1.apps-bue1.demo-lz.devcluster.openshift.com]
+time_namelookup  time_connect    time_starttransfer      time_total
+0.000046         0.229893        0.462351                0.463439
+0.000030         0.233715        0.468338                0.469316
+0.000057         0.230159        0.462013                0.463272
+0.000041         0.230470        0.462181                0.463116
+0.000044         0.228971        0.459642                0.460627
+~~~
+
+- Results of the **client** located in the region of **Brazil/South**:
+
+~~~text
+# Client Location: 
+["Florianópolis", "BR"]
+
+# Collecting request times to server running in AZs/Regular zones
+# [endpoint app-default-localzone-apps.apps.demo-lz.devcluster.openshift.com]
+time_namelookup time_connect time_starttransfer time_total
+0.022768        0.172481     0.324897           0.326504
+0.024175        0.178215     0.337317           0.338611
+0.029904        0.183622     0.338799           0.340016
+0.016936        0.172481     0.331656           0.333060
+0.023056        0.174012     0.332869           0.333940
+
+# Collecting request times to server running in Local Zone NYC
+# [endpoint k8s-localzon-ingressl-573f917a81-716983909.us-east-1.elb.amazonaws.com]
+time_namelookup time_connect time_starttransfer time_total
+0.023081        0.182175     0.339818           0.340769
+0.022908        0.187502     0.353711           0.354144
+0.024140        0.181430     0.342511           0.343637
+0.016736        0.175075     0.337191           0.338269
+0.017669        0.180589     0.342865           0.343365
+
+# Collecting request times to server running in Local Zone BUE
+# [endpoint app-bue-1.apps-bue1.demo-lz.devcluster.openshift.com]
+time_namelookup time_connect time_starttransfer time_total
+0.000016        0.044052     0.090594           0.091382
+0.000018        0.043565     0.090848           0.091869
+0.000015        0.046529     0.092182           0.092997
+0.000019        0.043899     0.089382           0.090326
+0.000016        0.044163     0.089726           0.090368
+~~~
+
+- Aggregated results:
+
+<p align="center">
+  <img src="https://github.com/mtulio/mtulio.labs/assets/3216894/9250fb62-fd99-4c31-9d77-178c82e38cb7" />
+  <p align="center"> Figure 9: Average connect and total time with slower points based on the baseline (fastest) </p>
+</p>
+
+The total time to connect, in milliseconds, from the client in NYC (outside AWS) to the OpenShift edge node running in the Local Zone was ~66% lower than the application running in the regular zones. It's also worth mentioning that there are benefits when clients accessing from different countries: the results from the client in Brazil decreased by more than 100% of the total request time when accessing the Buenos Aires deployment, instead of going to the Region's app due to the geographic proximity of those locations.
+
+<p align="center">
+  <img src="https://github.com/mtulio/mtulio.labs/assets/3216894/85c059f3-cfe5-4381-a4b4-fba7cce976d2" />
+  <p align="center"> Figure 10: Client in NYC getting better experience accessing the NYC Local Zone, than the app in the region </p>
+</p>
+
+
+## Summary
+
+OpenShift provides a platform for easy deployment, scaling, and management of containerized applications across the hybrid cloud including AWS. Using OpenShift with AWS Local Zones provides numerous benefits for organizations. It allows for lower latency and improved network performance as Local Zones are physically closer to end users, which enhances the overall user experience and reduces downtime. The combination of OpenShift and AWS Local Zones provides a flexible and scalable solution that enables organizations to modernize their applications and meet the demands of their customers and users:
+
+- 1) improving application performance and user experience,
+- 2) hosting resources in specific geographic locations reducing overall cost and
+- 3) providing regulated industries with a way to meet data residency requirements.
+
+
+## Categories
+
+- OpenShift 4
+- Edge
+- AWS
+- How-tos
+
+<!-- 
+External References
+ -->
+
+[aws-localzones]: https://aws.amazon.com/about-aws/global-infrastructure/localzones/
+
+[ocp-docs-localzone]: https://docs.openshift.com/container-platform/4.14/installing/installing_aws/installing-aws-localzone.html 
+
+[ocp-aws-cloudformation-localzone-subnet]: https://docs.openshift.com/container-platform/4.13/installing/installing_aws/installing-aws-localzone.html#installation-cloudformation-subnet-localzone_installing-aws-localzone
+
+[ocp-aws-albo]: https://docs.openshift.com/container-platform/4.12/networking/aws_load_balancer_operator/understanding-aws-load-balancer-operator.html
+
+[ocp-aws-albo-installing]: https://docs.openshift.com/container-platform/4.12/networking/aws_load_balancer_operator/install-aws-load-balancer-operator.html
+
+[ocp-aws-albo-controller]: https://docs.openshift.com/container-platform/4.12/networking/aws_load_balancer_operator/create-instance-aws-load-balancer-controller.html
+
+[ocp-aws-localzones-day2]: https://docs.openshift.com/container-platform/4.14/post_installation_configuration/aws-compute-edge-tasks
+<!-- Under development to 4.14:
+- https://github.com/openshift/openshift-docs/pull/60771
+- https://63729--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/aws-compute-edge-tasks -->
+
+[curl-vars-wout]: https://curl.se/docs/manpage.html#-w
+
+<!-- 
+Images hosted in github user content
+ -->
+
+[aws-infrastructure-continuum]: https://github.com/mtulio/mtulio.labs/assets/3216894/b4e68d09-bc65-40f4-91aa-1f1cbdea06e6
+
+[aws-local-zones-diagram-ocp-lz-413-map]: https://github.com/mtulio/mtulio.labs/assets/3216894/2fe7ae42-5b1a-4f7c-9e95-f063489eadc6
+
+[aws-local-zones-diagram-blog-hc-414-diagram]: https://github.com/mtulio/mtulio.labs/assets/3216894/6377e5ff-2489-46ce-8f1b-0f958f8c259a
+
+[ocp-aws-localzones-step4-ocp-nodes-ec2]: https://github.com/mtulio/mtulio.labs/assets/3216894/be37e2f6-f2cb-44e8-a5b5-c0961a603261
+
+[ocp-aws-localzones-step7-alb-nyc]: https://github.com/mtulio/mtulio.labs/assets/3216894/198527bf-773c-42b7-bcdc-30dc7a5a9aa9
+
+[ocp-aws-localzones-step7-alb-tg-nyc]: https://github.com/mtulio/mtulio.labs/assets/3216894/4129eef8-31cb-4373-822b-ec6b542cbce2
+
+[ocp-aws-localzones-step5-cfn-subnet-bue-1a]: https://github.com/mtulio/mtulio.labs/assets/3216894/6804bd3a-1104-4feb-9fa1-ca36a563e335
+
+[ocp-aws-localzones-step5-ec2-bue-1a]: https://github.com/mtulio/mtulio.labs/assets/3216894/74b19d65-e425-4c0a-8f45-a25e6449da46
+
+[ocp-aws-localzones-step8-aggregated-results]: https://github.com/mtulio/mtulio.labs/assets/3216894/9250fb62-fd99-4c31-9d77-178c82e38cb7
+
+[ocp-aws-localzones-step8-nyc]: https://github.com/mtulio/mtulio.labs/assets/3216894/85c059f3-cfe5-4381-a4b4-fba7cce976d2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,9 +128,10 @@ nav:
         - oc Plugin to install OCP on AWS extending to Local Zones (Day-0): articles/ocp-aws-local-zones-day-0-plugin.md
         - Patch MTU on Installed clusters with Local Zones: guides/ocp-aws-local-zones-day-2-patch-mtu.md
         - OCP + AWS Local Zones demo script: guides/ocp-aws-local-zones-demo.md
-        - Blog - Installing with Local Zone nodes in Existing VPC (4.13+): blogs/ocp-aws-local-zones/ocp-aws-local-zones-413.md
-        - Blog scripts - Installing with Local Zone nodes in Existing VPC (4.13+): blogs/ocp-aws-local-zones/ocp-aws-local-zones-413-script.md
-        - Blog HC - Installing with Local Zone nodes with full automation (4.14+): blogs/ocp-aws-local-zones/ocp-aws-local-zones-414.md
+        - Blog - Installing with Local Zone nodes with full automation (4.14+): blogs/ocp-aws-local-zones/ocp-aws-local-zones-414.md
+        - Blog demo - Installing with Local Zone nodes with full automation (4.14+): blogs/ocp-aws-local-zones/ocp-aws-local-zones-414-demo.md
+        - Blog - Installing Local Zone nodes in Existing VPC (4.13+): blogs/ocp-aws-local-zones/ocp-aws-local-zones-413.md
+        - Blog demo - Installing with Local Zone nodes in Existing VPC (4.13+): blogs/ocp-aws-local-zones/ocp-aws-local-zones-413-script.md
         - Blog HC - hands-on (Draft): guides/ocp-aws-local-zones-hands-on.md
 
       - OpenShift Dev:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,9 +126,12 @@ nav:
         - Extending OCP to AWS Local Zones (Day-2): ocp-aws-local-zones-day-2.md
         - Installing OCP on AWS extending to Local Zones (Day-0): ocp-aws-local-zones-day-0.md
         - oc Plugin to install OCP on AWS extending to Local Zones (Day-0): articles/ocp-aws-local-zones-day-0-plugin.md
-        - Blog HC - hands-on (Draft): guides/ocp-aws-local-zones-blog-hc.md
         - Patch MTU on Installed clusters with Local Zones: guides/ocp-aws-local-zones-day-2-patch-mtu.md
         - OCP + AWS Local Zones demo script: guides/ocp-aws-local-zones-demo.md
+        - Blog - Installing with Local Zone nodes in Existing VPC (4.13+): blogs/ocp-aws-local-zones/ocp-aws-local-zones-413.md
+        - Blog scripts - Installing with Local Zone nodes in Existing VPC (4.13+): blogs/ocp-aws-local-zones/ocp-aws-local-zones-413-script.md
+        - Blog HC - Installing with Local Zone nodes with full automation (4.14+): blogs/ocp-aws-local-zones/ocp-aws-local-zones-414.md
+        - Blog HC - hands-on (Draft): guides/ocp-aws-local-zones-hands-on.md
 
       - OpenShift Dev:
         - Build components: playbooks/openshift/dev-build-components.md


### PR DESCRIPTION
I am migrating the the Local Zones 4.13 content produced in https://github.com/mtulio/mtulio.labs/pull/23 to 4.14, which means removing all manual steps of creating the VPC.

This PR intends to preserve the work for posterity ;-)

The #23 should cover only 4.14.